### PR TITLE
feat: add automated static analysis with cppcheck and Coccinelle CI

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,21 +12,121 @@ on:
       - 'tools/analyze'
       - 'tools/cppcheck-suppressions.txt'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   static-analysis:
     runs-on: ubuntu-22.04
-    name: Run static analysis (cppcheck + Coccinelle)
+    name: Differential static analysis (cppcheck + Coccinelle)
 
     steps:
-    - name: Checkout the code
+    - name: Checkout PR code
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        path: pr-code
+
+    - name: Checkout base branch code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base-code
 
     - name: Install tools
       run: |
         sudo apt-get update
         sudo apt-get install -y cppcheck coccinelle
 
-    - name: Run static analysis
-      run: ./tools/analyze --ci
+    - name: Analyze PR code
+      working-directory: pr-code
+      run: ./tools/analyze --ci --output-dir /tmp/results-pr
+
+    # If the base branch lacks tools/analyze (or an older version without
+    # --output-dir), copy the PR's tooling into the base checkout.  The
+    # analyze script only reads source files — it never modifies them.
+    - name: Prepare base analysis tools
+      id: base-tools
+      run: |
+        if [ -x base-code/tools/analyze ] && \
+           grep -q 'output-dir' base-code/tools/analyze; then
+          echo "source=base" >> "$GITHUB_OUTPUT"
+        else
+          echo "source=pr" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Copy PR analysis tools to base (if needed)
+      if: steps.base-tools.outputs.source == 'pr'
+      run: |
+        mkdir -p base-code/tools/ci base-code/tools/coccinelle
+        cp pr-code/tools/analyze base-code/tools/analyze
+        cp pr-code/tools/coccicheck base-code/tools/coccicheck
+        cp -r pr-code/tools/coccinelle/ base-code/tools/coccinelle/
+        [ -f pr-code/tools/cppcheck-suppressions.txt ] && \
+          cp pr-code/tools/cppcheck-suppressions.txt base-code/tools/cppcheck-suppressions.txt
+        chmod +x base-code/tools/analyze base-code/tools/coccicheck
+
+    - name: Analyze base code
+      working-directory: base-code
+      run: ./tools/analyze --ci --output-dir /tmp/results-base
+
+    - name: Compare results
+      id: diff
+      continue-on-error: true
+      run: |
+        python3 pr-code/tools/ci/diff-static-analysis.py \
+          --base-dir /tmp/results-base \
+          --pr-dir   /tmp/results-pr   \
+          --output   /tmp/comment.md
+
+    - name: Post or update PR comment
+      if: always() && steps.diff.outcome != 'skipped'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const marker = '<!-- static-analysis-diff-comment -->';
+
+          let body;
+          try {
+            body = fs.readFileSync('/tmp/comment.md', 'utf8');
+          } catch {
+            body = marker + '\n## Static Analysis Results\n\n' +
+              'Analysis comparison failed. Check the workflow logs.';
+          }
+
+          const comments = await github.paginate(
+            github.rest.issues.listComments,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            }
+          );
+
+          const existing = comments.find(c => c.body.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+            core.info(`Updated existing comment ${existing.id}`);
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });
+            core.info('Created new comment');
+          }
+
+    - name: Fail if new findings
+      if: steps.diff.outcome == 'failure'
+      run: |
+        echo "New static analysis findings detected. See PR comment for details."
+        exit 1

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,32 @@
+name: Static Analysis
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'port/**'
+      - 'samples/**'
+      - 'tools/coccinelle/**'
+      - 'tools/coccicheck'
+      - 'tools/analyze'
+      - 'tools/cppcheck-suppressions.txt'
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-22.04
+    name: Run static analysis (cppcheck + Coccinelle)
+
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Install tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cppcheck coccinelle
+
+    - name: Run static analysis
+      run: ./tools/analyze --ci

--- a/tools/analyze
+++ b/tools/analyze
@@ -16,6 +16,7 @@ RUN_CPPCHECK=1
 RUN_COCCINELLE=1
 TARGETS=()
 DEFAULT_TARGETS=("src" "include" "port" "samples")
+OUTPUT_DIR=""
 
 CPPCHECK_RC=0
 COCCINELLE_RC=0
@@ -29,6 +30,9 @@ Run static analysis (cppcheck + Coccinelle) on the Hubble Device SDK.
 OPTIONS:
   -v, --verbose          Enable verbose output
   --ci                   CI mode (machine-readable output, no color)
+  --output-dir DIR       Save machine-readable results to DIR
+                         (cppcheck.xml, coccinelle.txt). Implies --ci.
+                         Always exits 0; use diff-static-analysis.py for pass/fail.
   --cppcheck-only        Run only cppcheck
   --coccinelle-only      Run only Coccinelle semantic patches
   -h, --help             Show this help and exit
@@ -94,6 +98,16 @@ while [ $# -gt 0 ]; do
 			RUN_COCCINELLE=0
 			shift
 			;;
+		--output-dir)
+			OUTPUT_DIR="$2"
+			CI_MODE=1
+			shift 2
+			;;
+		--output-dir=*)
+			OUTPUT_DIR="${1#*=}"
+			CI_MODE=1
+			shift
+			;;
 		--coccinelle-only)
 			RUN_CPPCHECK=0
 			RUN_COCCINELLE=1
@@ -126,6 +140,14 @@ if [ ${#TARGETS[@]} -eq 0 ]; then
 fi
 
 setup_colors
+
+if [ -n "$OUTPUT_DIR" ]; then
+	mkdir -p "$OUTPUT_DIR"
+	# Truncate so reruns against the same directory don't accumulate
+	# stale findings.  cppcheck.xml is naturally truncated by 2> but
+	# coccinelle.txt uses >> (append per target), so clear it here.
+	: > "$OUTPUT_DIR/coccinelle.txt"
+fi
 
 cd "$PROJECT_DIR"
 
@@ -173,7 +195,13 @@ run_cppcheck() {
 		CPPCHECK_FLAGS+=(--quiet)
 	fi
 
-	cppcheck "${CPPCHECK_FLAGS[@]}" "${TARGETS[@]}"
+	if [ -n "$OUTPUT_DIR" ]; then
+		# Capture XML to file; don't exit on findings — the diff
+		# script determines pass/fail.
+		cppcheck "${CPPCHECK_FLAGS[@]}" "${TARGETS[@]}" 2>"$OUTPUT_DIR/cppcheck.xml" || true
+	else
+		cppcheck "${CPPCHECK_FLAGS[@]}" "${TARGETS[@]}"
+	fi
 }
 
 # --- Coccinelle ---
@@ -250,6 +278,9 @@ run_coccinelle() {
 		if [ -n "$findings" ]; then
 			echo "$findings"
 			has_findings=1
+			if [ -n "$OUTPUT_DIR" ]; then
+				echo "$findings" >> "$OUTPUT_DIR/coccinelle.txt"
+			fi
 		fi
 	done
 
@@ -303,6 +334,12 @@ else
 fi
 
 echo ""
+
+# In output-dir mode the diff script determines pass/fail.
+if [ -n "$OUTPUT_DIR" ]; then
+	echo "Results saved to $OUTPUT_DIR"
+	exit 0
+fi
 
 if [ "$CPPCHECK_RC" -ne 0 ]; then
 	echo -e "${RED}Static analysis found issues.${RESET}"

--- a/tools/analyze
+++ b/tools/analyze
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Static analysis wrapper for the Hubble Device SDK.
+# Runs cppcheck and Coccinelle semantic patches against the codebase.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults
+VERBOSE=0
+CI_MODE=0
+RUN_CPPCHECK=1
+RUN_COCCINELLE=1
+TARGETS=()
+DEFAULT_TARGETS=("src" "include" "port" "samples")
+
+CPPCHECK_RC=0
+COCCINELLE_RC=0
+
+usage() {
+	cat <<EOF
+Usage: ./tools/analyze [OPTIONS] [DIRECTORY|FILE]...
+
+Run static analysis (cppcheck + Coccinelle) on the Hubble Device SDK.
+
+OPTIONS:
+  -v, --verbose          Enable verbose output
+  --ci                   CI mode (machine-readable output, no color)
+  --cppcheck-only        Run only cppcheck
+  --coccinelle-only      Run only Coccinelle semantic patches
+  -h, --help             Show this help and exit
+
+If no DIRECTORY or FILE is specified, analyzes: src/ include/ port/ samples/
+
+EXAMPLES:
+  ./tools/analyze                        # Analyze all default directories
+  ./tools/analyze src/hubble_ble.c       # Analyze a single file
+  ./tools/analyze --cppcheck-only src/   # Run only cppcheck on src/
+  ./tools/analyze --ci                   # CI mode for GitHub Actions
+EOF
+}
+
+# Colors (disabled in CI mode)
+RED=""
+GREEN=""
+YELLOW=""
+BOLD=""
+RESET=""
+
+setup_colors() {
+	if [ "$CI_MODE" -eq 0 ] && [ -t 1 ]; then
+		RED="\033[0;31m"
+		GREEN="\033[0;32m"
+		YELLOW="\033[0;33m"
+		BOLD="\033[1m"
+		RESET="\033[0m"
+	fi
+}
+
+log_header() {
+	echo ""
+	echo -e "${BOLD}=== $1 ===${RESET}"
+	echo ""
+}
+
+log_pass() {
+	echo -e "  ${GREEN}PASS${RESET}: $1"
+}
+
+log_fail() {
+	echo -e "  ${RED}FAIL${RESET}: $1"
+}
+
+log_skip() {
+	echo -e "  ${YELLOW}SKIP${RESET}: $1"
+}
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-v|--verbose)
+			VERBOSE=1
+			shift
+			;;
+		--ci)
+			CI_MODE=1
+			shift
+			;;
+		--cppcheck-only)
+			RUN_CPPCHECK=1
+			RUN_COCCINELLE=0
+			shift
+			;;
+		--coccinelle-only)
+			RUN_CPPCHECK=0
+			RUN_COCCINELLE=1
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		-*)
+			echo "Unknown option: $1"
+			usage
+			exit 2
+			;;
+		*)
+			if [ -e "$PROJECT_DIR/$1" ] || [ -e "$1" ]; then
+				TARGETS+=("$1")
+			else
+				echo "Error: '$1' does not exist"
+				exit 2
+			fi
+			shift
+			;;
+	esac
+done
+
+# Use default targets if none specified
+if [ ${#TARGETS[@]} -eq 0 ]; then
+	TARGETS=("${DEFAULT_TARGETS[@]}")
+fi
+
+setup_colors
+
+cd "$PROJECT_DIR"
+
+# --- cppcheck ---
+run_cppcheck() {
+	log_header "cppcheck"
+
+	if ! command -v cppcheck &>/dev/null; then
+		echo "Error: cppcheck not found. Install with:"
+		echo "  macOS:  brew install cppcheck"
+		echo "  Ubuntu: sudo apt-get install cppcheck"
+		return 1
+	fi
+
+	if [ "$VERBOSE" -eq 1 ]; then
+		echo "cppcheck version: $(cppcheck --version)"
+		echo "Targets: ${TARGETS[*]}"
+		echo ""
+	fi
+
+	local CPPCHECK_FLAGS=(
+		--enable=warning,style,performance,portability
+		--std=c99
+		--platform=unix32
+		--error-exitcode=1
+		--inline-suppr
+		-I include
+		-I src
+		-I port/zephyr
+		-I port/freertos
+		-I port/esp-idf
+		-i build
+	)
+
+	# Add suppressions file if it exists
+	if [ -f "$PROJECT_DIR/tools/cppcheck-suppressions.txt" ]; then
+		CPPCHECK_FLAGS+=(--suppressions-list="$PROJECT_DIR/tools/cppcheck-suppressions.txt")
+	fi
+
+	if [ "$CI_MODE" -eq 1 ]; then
+		CPPCHECK_FLAGS+=(--xml)
+	fi
+
+	if [ "$VERBOSE" -eq 0 ] && [ "$CI_MODE" -eq 0 ]; then
+		CPPCHECK_FLAGS+=(--quiet)
+	fi
+
+	cppcheck "${CPPCHECK_FLAGS[@]}" "${TARGETS[@]}"
+}
+
+# --- Coccinelle ---
+run_coccinelle() {
+	log_header "Coccinelle"
+
+	if ! command -v spatch &>/dev/null; then
+		echo "Error: spatch (Coccinelle) not found. Install with:"
+		echo "  macOS:  brew install coccinelle"
+		echo "  Ubuntu: sudo apt-get install coccinelle"
+		return 1
+	fi
+
+	# Quick sanity check that spatch actually works
+	if ! spatch --version &>/dev/null; then
+		echo "Error: spatch is installed but not functional."
+		echo "This can happen on macOS with Python library path issues."
+		echo "Try: brew reinstall coccinelle"
+		return 1
+	fi
+
+	if [ "$VERBOSE" -eq 1 ]; then
+		echo "spatch version: $(spatch --version 2>&1 | head -1)"
+		echo "Targets: ${TARGETS[*]}"
+		echo ""
+	fi
+
+	# coccicheck accepts a single directory argument.
+	# When custom targets are specified, run coccicheck once per target.
+	# When using defaults, let coccicheck scan the project root.
+	local cocci_targets=()
+	if [ "${TARGETS[*]}" = "${DEFAULT_TARGETS[*]}" ]; then
+		cocci_targets=("")
+	else
+		cocci_targets=("${TARGETS[@]}")
+	fi
+
+	local COCCI_FLAGS=("--mode=report")
+	if [ "$VERBOSE" -eq 1 ]; then
+		COCCI_FLAGS+=("-v=1")
+	fi
+
+	local has_findings=0
+	for target in "${cocci_targets[@]}"; do
+		local cocci_output
+		local cocci_rc=0
+		cocci_output=$("$SCRIPT_DIR/coccicheck" "${COCCI_FLAGS[@]}" $target 2>&1) || cocci_rc=$?
+
+		# Check if coccicheck itself failed (tool error, not findings)
+		if echo "$cocci_output" | grep -q "coccicheck failed"; then
+			echo "Error: coccicheck encountered a tool error."
+			if [ "$VERBOSE" -eq 1 ]; then
+				echo "$cocci_output"
+			else
+				echo "Run with -v for details."
+			fi
+			return 1
+		fi
+
+		# Filter out informational lines from coccicheck, keep only findings
+		local findings
+		findings=$(echo "$cocci_output" | grep -v "^$" \
+			| grep -v "^You have not explicitly" \
+			| grep -v "^Available modes" \
+			| grep -v "^You can specify" \
+			| grep -v "^Note however" \
+			| grep -v "^Please check" \
+			| grep -v "^When using" \
+			| grep -v "^----" \
+			| grep -v "^Processing" \
+			| grep -v "^with option" \
+			| grep -v "^$" || true)
+
+		if [ -n "$findings" ]; then
+			echo "$findings"
+			has_findings=1
+		fi
+	done
+
+	return $has_findings
+}
+
+# --- Main ---
+log_header "Hubble Device SDK - Static Analysis"
+echo "Targets: ${TARGETS[*]}"
+
+if [ "$RUN_CPPCHECK" -eq 1 ]; then
+	if run_cppcheck; then
+		CPPCHECK_RC=0
+	else
+		CPPCHECK_RC=$?
+	fi
+fi
+
+if [ "$RUN_COCCINELLE" -eq 1 ]; then
+	if run_coccinelle; then
+		COCCINELLE_RC=0
+	else
+		COCCINELLE_RC=$?
+	fi
+fi
+
+# --- Summary ---
+log_header "Summary"
+
+if [ "$RUN_CPPCHECK" -eq 1 ]; then
+	if [ "$CPPCHECK_RC" -eq 0 ]; then
+		log_pass "cppcheck"
+	else
+		log_fail "cppcheck"
+	fi
+else
+	log_skip "cppcheck"
+fi
+
+# Coccinelle is warn-only: existing codebase has findings and Coccinelle
+# has no baseline/suppression mechanism. Findings are reported but do not
+# fail the build. Remove this once existing findings are cleaned up.
+if [ "$RUN_COCCINELLE" -eq 1 ]; then
+	if [ "$COCCINELLE_RC" -eq 0 ]; then
+		log_pass "Coccinelle"
+	else
+		echo -e "  ${YELLOW}WARN${RESET}: Coccinelle (non-blocking, existing findings)"
+	fi
+else
+	log_skip "Coccinelle"
+fi
+
+echo ""
+
+if [ "$CPPCHECK_RC" -ne 0 ]; then
+	echo -e "${RED}Static analysis found issues.${RESET}"
+	exit 1
+fi
+
+echo -e "${GREEN}All checks passed.${RESET}"
+exit 0

--- a/tools/ci/diff-static-analysis.py
+++ b/tools/ci/diff-static-analysis.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# Compare static analysis results between a base branch and a PR to identify
+# new and fixed findings.  Produces a Markdown comment suitable for posting
+# to a GitHub pull request.
+#
+# Usage:
+#   python3 tools/ci/diff-static-analysis.py \
+#       --base-dir /tmp/results-base \
+#       --pr-dir   /tmp/results-pr   \
+#       --output   /tmp/comment.md
+#
+# Exit codes:
+#   0 — no new findings
+#   1 — new findings detected
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import NamedTuple
+
+# GitHub comment body limit (bytes).  Leave headroom for the marker/header.
+MAX_COMMENT_LEN = 60000
+
+COMMENT_MARKER = "<!-- static-analysis-diff-comment -->"
+
+
+class Finding(NamedTuple):
+    tool: str
+    filepath: str
+    rule_id: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+def parse_cppcheck_xml(xml_path):
+    """Parse cppcheck XML into a set of Finding tuples.
+
+    Line numbers are deliberately excluded so that findings which merely
+    shifted position (due to code added/removed above them) are still
+    recognised as the same finding.
+    """
+    findings = set()
+    if not xml_path.exists():
+        return findings
+
+    try:
+        tree = ET.parse(xml_path)
+    except ET.ParseError:
+        return findings
+
+    for error in tree.getroot().iter("error"):
+        error_id = error.get("id", "")
+        if error_id in ("information", "missingInclude", "missingIncludeSystem"):
+            continue
+
+        msg = error.get("msg", "")
+        location = error.find("location")
+        filepath = location.get("file", "") if location is not None else ""
+        findings.add(Finding("cppcheck", filepath, error_id, msg))
+
+    return findings
+
+
+def parse_coccinelle_text(txt_path):
+    """Parse Coccinelle report-mode text into a set of Finding tuples.
+
+    Expected formats produced by ``coccicheck --mode=report``:
+      filepath:line:col-col: message
+      filepath:line: message
+    """
+    findings = set()
+    if not txt_path.exists():
+        return findings
+
+    for raw_line in txt_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        # Split on the first colon that follows the filename.  Filenames may
+        # contain colons on some systems but our codebase uses simple paths.
+        parts = line.split(":", maxsplit=2)
+        if len(parts) < 3:
+            continue
+
+        filepath = parts[0]
+        # parts[1] is the line number — skip for line-agnostic matching.
+        message = parts[2].strip()
+        # Strip leading column range (e.g. "5-10: ") if present.
+        col_msg = message.split(":", maxsplit=1)
+        if len(col_msg) == 2 and col_msg[0].replace("-", "").strip().isdigit():
+            message = col_msg[1].strip()
+
+        findings.add(Finding("coccinelle", filepath, "", message))
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Markdown formatting
+# ---------------------------------------------------------------------------
+
+def _findings_table(findings, include_tool=False):
+    """Return a Markdown table for a set of findings."""
+    columns = []
+    if include_tool:
+        columns.append("Tool")
+    columns.extend(["File", "ID", "Message"])
+
+    header = "| " + " | ".join(columns) + " |"
+    sep = "| " + " | ".join("---" for _ in columns) + " |"
+    rows = [header, sep]
+    for f in sorted(findings):
+        cells = []
+        if include_tool:
+            cells.append(f.tool)
+        cells.append(f"`{f.filepath}`")
+        cells.append(f"`{f.rule_id}`" if f.rule_id else "")
+        cells.append(f.message)
+        rows.append("| " + " | ".join(cells) + " |")
+    return "\n".join(rows)
+
+
+def format_markdown(new_findings, fixed_findings):
+    """Format the diff as a GitHub PR comment."""
+    lines = [COMMENT_MARKER, "## Static Analysis Results", ""]
+
+    if not new_findings and not fixed_findings:
+        lines.append(
+            "No new static analysis findings. No findings fixed."
+        )
+        return "\n".join(lines)
+
+    if new_findings:
+        lines.append(
+            f"**{len(new_findings)} new finding(s) introduced by this PR:**"
+        )
+        lines.append("")
+
+        by_tool = {}
+        for f in new_findings:
+            by_tool.setdefault(f.tool, set()).add(f)
+
+        for tool in sorted(by_tool):
+            items = by_tool[tool]
+            lines.append(
+                f"<details><summary><b>{tool}</b> "
+                f"({len(items)} finding(s))</summary>\n"
+            )
+            lines.append(_findings_table(items))
+            lines.append("\n</details>\n")
+    else:
+        lines.append("**No new findings introduced by this PR.**")
+        lines.append("")
+
+    if fixed_findings:
+        lines.append(
+            f"**{len(fixed_findings)} finding(s) fixed by this PR:**"
+        )
+        lines.append("")
+        lines.append("<details><summary>Fixed findings</summary>\n")
+        lines.append(_findings_table(fixed_findings, include_tool=True))
+        lines.append("\n</details>")
+
+    body = "\n".join(lines)
+
+    # Truncate if the comment would exceed the GitHub size limit.
+    if len(body) > MAX_COMMENT_LEN:
+        truncation_msg = (
+            "\n\n---\n*Comment truncated — too many findings to display. "
+            "Run `./tools/analyze` locally for full results.*"
+        )
+        body = body[: MAX_COMMENT_LEN - len(truncation_msg)] + truncation_msg
+
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Diff static analysis results between base and PR."
+    )
+    parser.add_argument(
+        "--base-dir", required=True, help="Directory with base branch results"
+    )
+    parser.add_argument(
+        "--pr-dir", required=True, help="Directory with PR branch results"
+    )
+    parser.add_argument(
+        "--output", required=True, help="Path to write Markdown output"
+    )
+    args = parser.parse_args()
+
+    base_dir = Path(args.base_dir)
+    pr_dir = Path(args.pr_dir)
+
+    base_findings = set()
+    pr_findings = set()
+
+    base_findings |= parse_cppcheck_xml(base_dir / "cppcheck.xml")
+    base_findings |= parse_coccinelle_text(base_dir / "coccinelle.txt")
+
+    pr_findings |= parse_cppcheck_xml(pr_dir / "cppcheck.xml")
+    pr_findings |= parse_coccinelle_text(pr_dir / "coccinelle.txt")
+
+    new_findings = pr_findings - base_findings
+    fixed_findings = base_findings - pr_findings
+
+    markdown = format_markdown(new_findings, fixed_findings)
+    Path(args.output).write_text(markdown)
+
+    print(f"Base findings:  {len(base_findings)}")
+    print(f"PR findings:    {len(pr_findings)}")
+    print(f"New findings:   {len(new_findings)}")
+    print(f"Fixed findings: {len(fixed_findings)}")
+
+    if new_findings:
+        print("FAIL: New static analysis findings detected.")
+        return 1
+
+    print("PASS: No new static analysis findings.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/coccicheck
+++ b/tools/coccicheck
@@ -72,7 +72,7 @@ do
 			FILE="${i#*=}"
 			if [ ! -e "$FILE" ]; then
 				echo "unknown option: '${i#*=}'"
-	too			echo "$usage"
+				echo "$usage"
 				exit 2
 			fi
 			;;

--- a/tools/cppcheck-suppressions.txt
+++ b/tools/cppcheck-suppressions.txt
@@ -1,0 +1,62 @@
+// Hubble Device SDK - cppcheck baseline suppressions
+//
+// These suppress existing findings so CI enforces zero NEW findings.
+// Remove entries as the underlying code is fixed.
+//
+// Format: errorId:fileName:lineNumber
+
+// --- src/ ---
+
+// Return value check after early exit - intentional error propagation pattern
+identicalConditionAfterEarlyExit:src/hubble_ble.c:105
+
+// Ephemeris math: condition is always true due to prior sort guarantees
+knownConditionTrueFalse:src/hubble_sat_ephemeris.c:541
+
+// Intentional self-division for normalization
+duplicateExpression:src/hubble_sat_ephemeris.c:199
+
+// Ephemeris orbital constants used for physical correctness, not all referenced yet
+unusedStructMember:src/hubble_sat_ephemeris.c:40
+unusedStructMember:src/hubble_sat_ephemeris.c:41
+
+// Pointer constness suggestions in satellite packet encoding
+constVariablePointer:src/hubble_sat_packet.c:238
+constVariablePointer:src/hubble_sat_packet.c:335
+
+// Reed-Solomon encoder: variable scope and const suggestions
+variableScope:src/reed_solomon_encoder.c:127
+variableScope:src/reed_solomon_encoder.c:128
+constParameter:src/reed_solomon_encoder.c:125
+
+// Bitarray: error variable always zero after successful prior check
+knownConditionTrueFalse:src/utils/bitarray.c:81
+
+// --- port/ ---
+
+// FreeRTOS port: variable scope suggestion
+variableScope:port/freertos/hubble_freertos.c:68
+
+// Satellite board offset tables could be const
+constVariable:port/freertos/hubble_sat_freertos.c:34
+constVariable:port/zephyr/hubble_sat_zephyr.c:26
+
+// --- samples/ ---
+
+// Callback parameter constness - cannot change without breaking callback signatures
+constParameterCallback:samples/esp-idf/ble-beacon/main/main.c:93
+constParameterCallback:samples/zephyr/ble-beacon/src/main.c:110
+constParameterCallback:samples/zephyr/ble-network/src/main.c:45
+
+// TI sample: pointer constness and uninitialized variable
+constVariablePointer:samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c:139
+uninitvar:samples/freertos/ti/ble-beacon/src/hubble_ble_adv.c:151
+
+// TI sample: platform-specific ALIGNED macro not known to cppcheck
+unknownMacro:samples/freertos/ti/ble-beacon/src/hubble_ble_ti.c:37
+
+// TI sample: unused variable (platform-specific verification)
+unusedVariable:samples/freertos/ti/ble-beacon/src/hubble_ble_ti.c:36
+
+// Zephyr sample: variable scope suggestion
+variableScope:samples/zephyr/ble-network/src/main.c:49


### PR DESCRIPTION
Add a unified `tools/analyze` script that runs cppcheck and the existing Coccinelle semantic patches against src/, include/, port/, and samples/. A new GitHub Actions workflow enforces zero new findings on pull requests.

Existing cppcheck findings are baselined in a suppressions file so CI enforces only new regressions. The coccicheck typo on line 75 is also fixed.