### PR TITLE
test: add riglink host-driven BLE round-trip test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@ docs/_doxygen/
 # Build artifacts
 **/twister-out*/
 **/build/**
+tests/riglink/build-*/
 .cache/
+
+# Python
+**/__pycache__/
+*.pyc
 
 # generated files
 **/key.c

--- a/tests/riglink/CMakeLists.txt
+++ b/tests/riglink/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Hubble Network
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(riglink_ble_test)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/riglink/README.md
+++ b/tests/riglink/README.md
@@ -1,0 +1,109 @@
+# riglink BLE Test
+
+A host-driven test of the BLE advertisement API in `include/hubble/ble.h`. A
+Python host drives the SDK firmware over a serial link using
+[riglink](https://github.com/buckleypaul/riglink): it sets a known master
+key, a fixed (overridden) uptime, and a fixed sequence counter, asks the
+firmware to generate an advertisement via `hubble_ble_advertise_get()`, then
+verifies the result both byte-matches and decrypts against the reference
+oracle in `tools/hubble_ref_crypto.py`.
+
+No radio is used (`CONFIG_BT=n`); the firmware only exposes the API over
+riglink. The same firmware therefore runs unchanged on `native_sim` and on an
+`nrf52840dk`.
+
+## Layout
+
+- `src/main.c` — firmware that exposes the BLE advertisement API over riglink.
+- `boards/` — board overlays (`native_sim`, `native_sim_native_64`,
+  `nrf52840dk_nrf52840`).
+- `python/` — the pytest harness:
+  - `conftest.py` — builds and launches the `native_sim` app and connects
+    riglink over its pseudotty; with `--riglink-port` it instead targets an
+    attached device.
+  - `test_ble.py` — integration tests driving the firmware over riglink.
+  - `test_reference.py` — host-only tests of the reference oracle.
+  - `requirements.txt` — host Python dependencies.
+- The reference oracle lives at `tools/hubble_ref_crypto.py`.
+
+This is a standalone Zephyr application plus a pytest harness; it is **not**
+run via `west twister`.
+
+## Prerequisites
+
+The `riglink` and `jcon` modules are declared in the workspace `west.yml`.
+Fetch them with:
+
+```sh
+west update riglink jcon
+```
+
+Host Python dependencies (`pycryptodome`, `bitstring`, `pytest`, and
+`riglink`) are listed in `tests/riglink/python/requirements.txt`. Note that
+`riglink` is not on PyPI; install it from the workspace clone at
+`modules/lib/riglink/python`.
+
+## Run on native_sim
+
+Zephyr's `native_sim` (POSIX arch) only builds on Linux. On macOS or Windows,
+run the suite inside a Linux Docker container.
+
+### Docker (macOS / Windows / any host)
+
+The image `ghcr.io/zephyrproject-rtos/ci:v0.28.7` bundles Zephyr SDK 0.17.4,
+matching the checked-out Zephyr. Mount the whole west workspace at
+`/workspace`:
+
+```sh
+docker run --rm \
+  -v <workspace-root>:/workspace \
+  -w /workspace/hubble-device-sdk/tests/riglink/python \
+  -e ZEPHYR_BASE=/workspace/zephyr \
+  -e ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.17.4 \
+  -e HOME=/tmp \
+  ghcr.io/zephyrproject-rtos/ci:v0.28.7 \
+  bash -c "pip install -q pycryptodome bitstring pytest && pip install -q -e /workspace/modules/lib/riglink/python && python -m pytest -v"
+```
+
+`<workspace-root>` is the west topdir — the directory that contains `zephyr/`,
+`modules/`, and `hubble-device-sdk/`.
+
+### Native Linux
+
+On a Linux host that already has a Zephyr environment and `west`:
+
+```sh
+cd tests/riglink/python
+pip install -r requirements.txt
+python -m pytest -v
+```
+
+The conftest auto-builds `native_sim/native/64` and connects to the firmware
+over its pseudotty.
+
+## Run on an attached nrf52840dk
+
+Flash the app, then point pytest at the device's serial port:
+
+```sh
+west build -b nrf52840dk/nrf52840 tests/riglink
+west flash
+cd tests/riglink/python
+python -m pytest -v -p no:cacheprovider --riglink-port /dev/ttyACM0
+```
+
+The `--riglink-port` option is provided by riglink's own pytest plugin. Its
+device-path value (e.g. `/dev/ttyACM0`) looks like a filesystem path to
+pytest's `rootdir` detection, which then tries to write its cache under that
+read-only location; `-p no:cacheprovider` disables the unused cache and avoids
+the resulting warning.
+
+## Scope and follow-ons
+
+This test covers the v1 configuration: 256-bit master key, PSA crypto backend,
+and the Unix-time counter source. Planned follow-ons:
+
+- 128-bit master key.
+- MbedTLS crypto backend.
+- Real RF broadcast and scan (radio enabled).
+- twister / CI integration.

--- a/tests/riglink/boards/native_sim.overlay
+++ b/tests/riglink/boards/native_sim.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Hubble Network
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The harness builds native_sim/native/64, which uses
+ * native_sim_native_64.overlay. This bare-name overlay exists only so a plain
+ * native_sim build resolves too; include the qualified one so the riglink
+ * shell-uart binding is defined in a single place.
+ */
+
+#include "native_sim_native_64.overlay"

--- a/tests/riglink/boards/native_sim_native_64.overlay
+++ b/tests/riglink/boards/native_sim_native_64.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Hubble Network
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * riglink's shell backend binds to zephyr,shell-uart; put it on uart1 (its own
+ * pseudotty) and leave zephyr,console on the default native uart (uart0), so
+ * console output stays off the riglink wire. Matches the native_sim/native/64
+ * board qualifier used by the test harness.
+ */
+
+/ {
+	chosen {
+		zephyr,shell-uart = &uart1;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/tests/riglink/boards/nrf52840dk_nrf52840.conf
+++ b/tests/riglink/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Hubble Network
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# On the DK, riglink's shell backend takes over uart0 (the J-Link VCOM). The
+# kernel console and boot banner write to that same UART via printk and would
+# inject plain text into riglink's sentinel-framed JSON stream, so silence them
+# and let the shell own the wire. (Logging is already disabled globally in
+# prj.conf.) native_sim is unaffected: there the shell uses a dedicated
+# pseudotty (uart1) while the console stays on uart0.
+CONFIG_UART_CONSOLE=n
+CONFIG_BOOT_BANNER=n

--- a/tests/riglink/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/riglink/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Hubble Network
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * riglink's shell backend takes over uart0 (the J-Link VCOM). Bind
+ * zephyr,shell-uart to it explicitly; the board .conf silences the console and
+ * logging so uart0 carries only riglink's sentinel-framed JSON.
+ */
+
+/ {
+	chosen {
+		zephyr,shell-uart = &uart0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+};

--- a/tests/riglink/prj.conf
+++ b/tests/riglink/prj.conf
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 Hubble Network
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Hubble SDK: BLE, Unix-time counter, fully host-controlled determinism.
+CONFIG_HUBBLE_BLE_NETWORK=y
+CONFIG_HUBBLE_NETWORK_KEY_256=y
+CONFIG_HUBBLE_COUNTER_SOURCE_UNIX_TIME=y
+CONFIG_HUBBLE_NETWORK_CRYPTO_PSA=y
+CONFIG_HUBBLE_UPTIME_CUSTOM=y
+CONFIG_HUBBLE_NETWORK_SEQUENCE_NONCE_CUSTOM=y
+
+# The host replays fixed sequence counters (e.g. seq 0 in several tests) to
+# verify each advertisement against the reference oracle. Disable the
+# nonce-reuse guard, which would otherwise reject the intentionally repeated
+# counters; uniqueness is irrelevant to this deterministic test fixture.
+CONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK=n
+
+# No radio is used; we only exercise advertisement generation.
+CONFIG_BT=n
+
+# Transport: riglink over Zephyr's shell backend. The shell owns the UART, so
+# RX is interrupt-driven and won't drop bytes at 115200 (no hand-rolled ISR or
+# rig_getc/rig_putc shims), and each command is dispatched as a subcommand of
+# "rig" -- the host targets it with shell_root="rig".
+CONFIG_RIGLINK=y
+CONFIG_RIGLINK_BACKEND_SHELL=y
+CONFIG_RIGLINK_MEM_ACCESS=n
+CONFIG_SERIAL=y
+CONFIG_REBOOT=y
+
+# Shell (selected by RIGLINK_BACKEND_SHELL, which also pulls in JCON and the
+# serial backend) configured for machine-driven I/O: no prompt, echo, or ANSI
+# escapes that would corrupt the sentinel-framed JSON response stream.
+CONFIG_SHELL_PROMPT_UART=""
+CONFIG_SHELL_VT100_COMMANDS=n
+CONFIG_SHELL_ECHO_STATUS=n
+CONFIG_SHELL_HELP=n
+CONFIG_SHELL_HISTORY=n
+CONFIG_SHELL_METAKEYS=n
+CONFIG_SHELL_TAB=n
+CONFIG_SHELL_STATS=n
+CONFIG_SHELL_CMD_BUFF_SIZE=256
+CONFIG_SHELL_ARGC_MAX=10
+# The shell's RX ring buffer defaults to 64 bytes, but the longest command line
+# -- "rig test_init <64-char key hex> <epoch>" -- is ~93 bytes. A line that
+# overflows the ring drops bytes mid-token, corrupting the command (a split key
+# arrives as an extra argument). Size the ring to the command buffer.
+CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=256
+# Commands run on the shell thread, not main(). adv_get/test_init call into PSA
+# crypto (hubble_init, AES/CMAC) on top of riglink's str-arg trampoline, so give
+# the shell thread the same stack the main thread had in the polled backend.
+CONFIG_SHELL_STACK_SIZE=4096
+
+# Keep the shell UART carrying only riglink's JSON: no logging to interleave
+# with (and corrupt) response frames on the same wire.
+CONFIG_LOG=n
+
+CONFIG_MAIN_STACK_SIZE=4096

--- a/tests/riglink/python/conftest.py
+++ b/tests/riglink/python/conftest.py
@@ -1,0 +1,166 @@
+"""pytest configuration for the riglink BLE test harness.
+
+Without --riglink-port, builds and launches the tests/riglink app on
+native_sim and connects riglink to its pseudotty. With --riglink-port,
+connects to an already-flashed device (e.g. an nrf52840dk).
+"""
+import os
+import re
+import select
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+import riglink
+
+_HERE = os.path.dirname(__file__)
+_APP_DIR = os.path.abspath(os.path.join(_HERE, ".."))
+_TOOLS = os.path.abspath(os.path.join(_HERE, "..", "..", "..", "tools"))
+if _TOOLS not in sys.path:
+    sys.path.insert(0, _TOOLS)
+
+_PTY_RE = re.compile(r"connected to pseudotty:\s*(\S+)")
+_BAUD = 115200
+# The firmware uses riglink's shell backend, so commands are dispatched as
+# subcommands of this root command; shell_root routes outbound calls to it.
+_SHELL_ROOT = "rig"
+
+
+# --riglink-port / --riglink-baud are registered by the always-installed
+# riglink pytest plugin (riglink.pytest_plugin), so we deliberately do NOT
+# re-register them -- doing so collides with the plugin and aborts collection.
+# We only read them. The plugin makes --riglink-port an append-action option
+# (dest "riglink_port"), so getoption() returns a list; we take the first port.
+
+def _riglink_port(config):
+    """First configured serial port, or None when running on native_sim.
+
+    Falls back to None if the plugin is somehow absent so the no-port
+    (native_sim) auto-build path still works.
+    """
+    try:
+        val = config.getoption("--riglink-port")
+    except (ValueError, KeyError):
+        return None
+    if not val:
+        return None
+    if isinstance(val, (list, tuple)):
+        return val[0] if val else None
+    return val
+
+
+def _riglink_baud(config):
+    try:
+        val = config.getoption("--riglink-baud")
+    except (ValueError, KeyError):
+        return _BAUD
+    return val if val else _BAUD
+
+
+class _NativeSim:
+    """Builds, launches, and connects to the tests/riglink app on native_sim."""
+
+    def __init__(self):
+        self._build_dir = os.path.join(_APP_DIR, "build-native_sim")
+        self.proc = None
+        self.dev = None
+        self._drain = None
+
+    def build(self):
+        subprocess.run(
+            ["west", "build", "-b", "native_sim/native/64", "-d", self._build_dir,
+             _APP_DIR],
+            check=True,
+        )
+
+    def launch(self):
+        exe = os.path.join(self._build_dir, "zephyr", "zephyr.exe")
+        self.proc = subprocess.Popen(
+            [exe], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1,
+        )
+        # native_sim opens uart0 (console) first, then uart1 (riglink's PTY),
+        # emitting one "connected to pseudotty:" line per UART. We want the
+        # riglink UART, which is the last one reported, so keep scanning until
+        # a brief quiet period after the latest match (mirrors riglink's own
+        # reference harness) rather than breaking on the first line.
+        # The 0.25s quiet window and 0.05s poll interval are heuristic timing
+        # values (not protocol-derived) and may be tuned if startup is slower.
+        deadline = time.monotonic() + 10.0
+        pty = None
+        last_match_at = None
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([self.proc.stdout], [], [], 0.05)
+            if not ready:
+                if (pty is not None and last_match_at is not None
+                        and time.monotonic() - last_match_at > 0.25):
+                    break
+                if self.proc.poll() is not None:
+                    break
+                continue
+            line = self.proc.stdout.readline()
+            if not line:
+                if self.proc.poll() is not None:
+                    break
+                continue
+            m = _PTY_RE.search(line)
+            if m:
+                pty = m.group(1)
+                last_match_at = time.monotonic()
+        if not pty:
+            self.teardown()
+            pytest.skip("native_sim did not report a pseudotty")
+        # Keep draining stdout so the OS pipe never fills and backpressures
+        # (which would stall the simulator). riglink drives I/O over the PTY,
+        # so the captured stdout is only diagnostic console output.
+        self._drain = threading.Thread(target=self._drain_stdout, daemon=True)
+        self._drain.start()
+        time.sleep(0.2)  # let the PTY settle
+        self.dev = riglink.connect(pty, _BAUD, shell_root=_SHELL_ROOT)
+
+    def _drain_stdout(self):
+        try:
+            for _ in iter(self.proc.stdout.readline, ""):
+                pass  # discard; loop ends at EOF when the process exits
+        except Exception:
+            pass  # swallow errors raised by pipe close during teardown
+
+    def teardown(self):
+        if self.dev is not None:
+            self.dev.close()
+            self.dev = None
+        if self.proc is not None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+            self.proc = None
+        # Daemon thread ends on stdout EOF once the process is gone; no join.
+        self._drain = None
+
+
+@pytest.fixture(scope="session")
+def _device(request):
+    port = _riglink_port(request.config)
+    if port:
+        baud = _riglink_baud(request.config)
+        dev = riglink.connect(port, baud, shell_root=_SHELL_ROOT)
+        yield dev
+        dev.close()
+    else:
+        sim = _NativeSim()
+        sim.build()
+        sim.launch()
+        yield sim.dev
+        sim.teardown()
+
+
+@pytest.fixture
+def dev(_device):
+    # Every test sets key/uptime/seq explicitly, so tests are self-contained;
+    # just clear any buffered bytes from a prior test.
+    _device.clear_buffers()
+    return _device

--- a/tests/riglink/python/requirements.txt
+++ b/tests/riglink/python/requirements.txt
@@ -1,0 +1,4 @@
+pycryptodome
+bitstring
+riglink
+pytest

--- a/tests/riglink/python/test_ble.py
+++ b/tests/riglink/python/test_ble.py
@@ -1,0 +1,61 @@
+"""Host-driven BLE round-trip tests over riglink.
+
+The host sets a known key, a fixed (overridden) uptime, and a fixed sequence
+counter, then asks the firmware to generate an advertisement. The result must
+byte-match the reference oracle AND decrypt back to the input payload.
+"""
+import pytest
+
+from hubble_ref_crypto import build_advertisement, decrypt_advertisement
+
+KEY_HEX = "cd15a5abc060b67288a61e44e995ba77d140bd46564b88de41c15a9273b0ce85"
+KEY = bytes.fromhex(KEY_HEX)
+EPOCH_MS = 1760210751803
+
+# (seq, payload_bytes)
+CASES = [
+    (0, b""),
+    (1, bytes.fromhex("deadbeef")),
+    (5, bytes.fromhex("00112233445566778899aabbcc")),  # 13 bytes (max)
+    (1023, b"\x42"),                                    # max seq
+]
+
+
+def _make_adv(dev, seq, payload):
+    assert dev.test_init(KEY_HEX, EPOCH_MS)["ret"] == 0
+    assert dev.test_set_uptime(0)["ret"] is None
+    assert dev.test_set_seq(seq)["ret"] is None
+    res = dev.adv_get(payload.hex())
+    assert res["ret"] == 0
+    return bytes.fromhex(res["adv_hex"]), res["adv_len"]
+
+
+@pytest.mark.parametrize("seq,payload", CASES)
+def test_adv_matches_reference(dev, seq, payload):
+    adv, adv_len = _make_adv(dev, seq, payload)
+    assert adv_len == len(adv)
+    assert adv == build_advertisement(KEY, EPOCH_MS, seq, payload)
+
+
+@pytest.mark.parametrize("seq,payload", CASES)
+def test_adv_decrypts_to_payload(dev, seq, payload):
+    adv, _ = _make_adv(dev, seq, payload)
+    _, got_seq, got_payload = decrypt_advertisement(KEY, adv, EPOCH_MS)
+    assert got_seq == seq
+    assert got_payload == payload
+
+
+def test_adv_rejects_oversized_payload(dev):
+    assert dev.test_init(KEY_HEX, EPOCH_MS)["ret"] == 0
+    dev.test_set_uptime(0)
+    dev.test_set_seq(0)
+    res = dev.adv_get(("aa" * 14))  # 14 bytes > HUBBLE_BLE_MAX_DATA_LEN (13)
+    assert res["ret"] != 0
+
+
+def test_expiration_within_rotation_period(dev):
+    assert dev.test_init(KEY_HEX, EPOCH_MS)["ret"] == 0
+    dev.test_set_uptime(0)
+    res = dev.hubble_ble_advertise_expiration_get()
+    rotation_ms = 86400 * 1000
+    assert 0 < res["ret"] <= rotation_ms

--- a/tests/riglink/python/test_reference.py
+++ b/tests/riglink/python/test_reference.py
@@ -1,0 +1,41 @@
+"""Host-only tests for the reference crypto oracle.
+
+Golden vectors are taken from tests/zephyr/ble-network/src/main.c so the
+reference is validated against values the firmware is already known to
+produce.
+"""
+import pytest
+
+from hubble_ref_crypto import build_advertisement, decrypt_advertisement
+
+KEY = bytes.fromhex(
+    "cd15a5abc060b67288a61e44e995ba77d140bd46564b88de41c15a9273b0ce85"
+)
+EPOCH_MS = 1760210751803
+
+GOLDEN = [
+    (0, b"", bytes.fromhex("a6fc0000c048b6337f4f35bb")),
+    (1, bytes.fromhex("deadbeef"),
+     bytes.fromhex("a6fc0001c048b63345a8aec6c02eacf0")),
+]
+
+
+@pytest.mark.parametrize("seq,payload,expected", GOLDEN)
+def test_build_matches_golden(seq, payload, expected):
+    adv = build_advertisement(KEY, EPOCH_MS, seq, payload)
+    assert adv == expected
+
+
+@pytest.mark.parametrize("seq,payload,expected", GOLDEN)
+def test_decrypt_round_trip(seq, payload, expected):
+    _, got_seq, got_payload = decrypt_advertisement(KEY, expected, EPOCH_MS)
+    assert got_seq == seq
+    assert got_payload == payload
+
+
+def test_decrypt_rejects_bad_tag():
+    adv = build_advertisement(KEY, EPOCH_MS, 0, b"\x01\x02")
+    tampered = bytearray(adv)
+    tampered[-1] ^= 0xFF  # corrupt last ciphertext byte
+    with pytest.raises(ValueError):
+        decrypt_advertisement(KEY, bytes(tampered), EPOCH_MS)

--- a/tests/riglink/src/main.c
+++ b/tests/riglink/src/main.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Hubble Network
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Host-driven test fixture: exposes the Hubble BLE advertisement API over
+ * riglink, with uptime and the sequence counter overridden so the host can
+ * make advertisements fully deterministic and verify them by decryption.
+ *
+ * Transport is riglink's Zephyr shell backend (CONFIG_RIGLINK_BACKEND_SHELL):
+ * the shell owns the UART -- so RX is interrupt-driven and won't drop bytes --
+ * and dispatches each command below as a subcommand of "rig" (the host targets
+ * it with shell_root="rig"). This file therefore implements no rig_putc /
+ * rig_getc and no rig_init() / rig_run() pump; the backend brings all of that
+ * up via SYS_INIT.
+ */
+/* The largest str argument is the 64-char (256-bit) master key hex passed to
+ * test_init; riglink's default per-arg buffer is 64 bytes, which would
+ * truncate it to 63 chars (odd length -> decode failure). Size it to fit the
+ * key hex plus the NUL terminator before including riglink.h.
+ */
+#define RIG_STR_ARG_SIZE 96
+#include <riglink.h>
+
+#include <hubble/hubble.h>
+
+#include <zephyr/sys/util.h>
+
+#include <string.h>
+
+/* --- host-controlled SDK port overrides (enabled via *_CUSTOM Kconfig) --- */
+
+static uint64_t test_uptime_ms;
+static uint16_t test_seq;
+
+uint64_t hubble_uptime_get(void)
+{
+	return test_uptime_ms;
+}
+
+uint16_t hubble_sequence_counter_get(void)
+{
+	return test_seq;
+}
+
+/* --- helpers --- */
+
+/* hubble_init/hubble_key_set store the key pointer without copying, so the
+ * buffer must outlive every advertisement call: keep it static.
+ */
+static uint8_t master_key[CONFIG_HUBBLE_KEY_SIZE];
+
+/* --- exposed surface --- */
+
+RIG_FN(int, test_init, str, uint64_t)
+{
+	if (hex2bin(arg0, strlen(arg0), master_key, sizeof(master_key)) !=
+	    sizeof(master_key)) {
+		return -1;
+	}
+	test_uptime_ms = 0U;
+	test_seq = 0U;
+	return hubble_init(arg1, master_key);
+}
+
+RIG_FN(void, test_set_uptime, uint64_t)
+{
+	test_uptime_ms = arg0;
+}
+
+RIG_FN(void, test_set_seq, uint16_t)
+{
+	test_seq = arg0;
+}
+
+RIG_FN(int, adv_get, str)
+{
+	uint8_t input[HUBBLE_BLE_MAX_DATA_LEN + 1];
+	uint8_t out[HUBBLE_BLE_ADV_HEADER_SIZE + HUBBLE_BLE_MAX_DATA_LEN + 1];
+	char hexout[2U * sizeof(out) + 1U];
+	size_t out_len = sizeof(out);
+	size_t hlen = strlen(arg0);
+	size_t in_len = hex2bin(arg0, hlen, input, sizeof(input));
+
+	/* hex2bin returns 0 for both an empty payload (valid) and a decode
+	 * failure; only a non-empty input that decoded to nothing is an error.
+	 */
+	if (in_len == 0U && hlen != 0U) {
+		return -1;
+	}
+
+	int status = hubble_ble_advertise_get(input, in_len, out, &out_len);
+
+	if (status != 0) {
+		return status;
+	}
+
+	bin2hex(out, out_len, hexout, sizeof(hexout));
+
+	rig_emit("adv_hex", hexout);
+	rig_emit("adv_len", (int64_t)out_len);
+	return 0;
+}
+
+RIG_EXPOSE(uint32_t, hubble_ble_advertise_expiration_get);
+
+int main(void)
+{
+	/* The riglink shell backend runs the link from SYS_INIT and the shell
+	 * thread; the main thread has nothing to do.
+	 */
+	return 0;
+}

--- a/tools/ble-adv.py
+++ b/tools/ble-adv.py
@@ -12,70 +12,13 @@ Simple application to advertise data through Hubble BLE Network.
 import argparse
 import base64
 
-from bitstring import BitArray
-
-from Crypto.Cipher import AES
-from Crypto.Hash import CMAC
-from Crypto.Protocol.KDF import SP800_108_Counter
-
-HUBBLE_AES_KEY_SIZE = 32
-HUBBLE_AES_NONCE_SIZE = 12
-HUBBLE_DEVICE_ID_SIZE = 4
-HUBBLE_AES_TAG_SIZE = 4
-
-
-def generate_kdf_key(key: bytes, key_size: int, label: str,
-                     context: int) -> bytes:
-    label = label.encode()
-    context = str(context).encode()
-
-    return SP800_108_Counter(
-        key,
-        key_size,
-        lambda session_key, data: CMAC.new(session_key, data, AES).digest(),
-        label=label,
-        context=context,
-    )
-
-
-def get_device_id(master_key: bytes, time_counter: int) -> int:
-    device_key = generate_kdf_key(master_key, HUBBLE_AES_KEY_SIZE,
-                                  'DeviceKey', time_counter)
-    device_id = generate_kdf_key(device_key, HUBBLE_DEVICE_ID_SIZE,
-                                 'DeviceID', 0)
-
-    return int.from_bytes(device_id, byteorder='big')
-
-
-def get_nonce(master_key: bytes, time_counter: int, counter: int) -> bytes:
-    nonce_key = generate_kdf_key(
-        master_key, HUBBLE_AES_KEY_SIZE, "NonceKey", time_counter
-    )
-
-    return generate_kdf_key(nonce_key, HUBBLE_AES_NONCE_SIZE, "Nonce", counter)
-
-
-def get_encryption_key(master_key: bytes, time_counter: int,
-                       counter: int) -> bytes:
-    encryption_key = generate_kdf_key(
-        master_key, HUBBLE_AES_KEY_SIZE, "EncryptionKey", time_counter
-    )
-
-    return generate_kdf_key(encryption_key, HUBBLE_AES_KEY_SIZE,
-                            'Key', counter)
-
-
-def get_auth_tag(key: bytes, ciphertext: bytes) -> bytes:
-    computed_cmac = CMAC.new(key, ciphertext, AES).digest()
-
-    return computed_cmac[:HUBBLE_AES_TAG_SIZE]
-
-
-def aes_encrypt(key: bytes, nonce_session: bytes, data: bytes) -> bytes:
-    ciphertext = AES.new(key, AES.MODE_CTR, nonce=nonce_session).encrypt(data)
-    tag = get_auth_tag(key, ciphertext)
-
-    return ciphertext, tag
+from hubble_ref_crypto import (
+    generate_ble_adv,
+    get_device_id,
+    get_nonce,
+    get_encryption_key,
+    aes_encrypt,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -112,24 +55,6 @@ def parse_args() -> argparse.Namespace:
                              "transmitting via BLE")
 
     return parser.parse_args()
-
-
-def generate_ble_adv(device_id, seq_no, auth_tag, encrypted_payload) -> bytes:
-    ble_adv = BitArray()
-
-    if len(encrypted_payload) > 13:
-        raise ValueError('Encrypted Payload is too long.')
-
-    protocol_version = 0b000000
-
-    ble_adv.append(f'uint:6={protocol_version}')
-    ble_adv.append(f'uint:10={seq_no}')
-    ble_adv.append(f'uint:32={device_id}')
-
-    ble_adv.append(auth_tag)
-    ble_adv.append(encrypted_payload)
-
-    return ble_adv.tobytes()
 
 
 def format_c_hex(data: bytes) -> str:

--- a/tools/hubble_ref_crypto.py
+++ b/tools/hubble_ref_crypto.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Hubble Network, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reference implementation of the Hubble BLE advertisement crypto.
+
+This mirrors the on-wire format produced by hubble_ble_advertise_get(). It is
+the single source of truth shared by tools/ble-adv.py and the riglink test
+harness.
+"""
+
+from bitstring import BitArray
+
+from Crypto.Cipher import AES
+from Crypto.Hash import CMAC
+from Crypto.Protocol.KDF import SP800_108_Counter
+
+HUBBLE_AES_KEY_SIZE = 32
+HUBBLE_AES_NONCE_SIZE = 12
+HUBBLE_DEVICE_ID_SIZE = 4
+HUBBLE_AES_TAG_SIZE = 4
+HUBBLE_UUID_PREFIX = bytes([0xA6, 0xFC])
+HUBBLE_ROTATION_PERIOD_SEC = 86400
+
+
+def generate_kdf_key(key: bytes, key_size: int, label: str,
+                     context: int) -> bytes:
+    return SP800_108_Counter(
+        key,
+        key_size,
+        lambda session_key, data: CMAC.new(session_key, data, AES).digest(),
+        label=label.encode(),
+        context=str(context).encode(),
+    )
+
+
+def get_device_id(master_key: bytes, time_counter: int) -> int:
+    device_key = generate_kdf_key(master_key, HUBBLE_AES_KEY_SIZE,
+                                  'DeviceKey', time_counter)
+    device_id = generate_kdf_key(device_key, HUBBLE_DEVICE_ID_SIZE,
+                                 'DeviceID', 0)
+    return int.from_bytes(device_id, byteorder='big')
+
+
+def get_nonce(master_key: bytes, time_counter: int, counter: int) -> bytes:
+    nonce_key = generate_kdf_key(master_key, HUBBLE_AES_KEY_SIZE,
+                                 "NonceKey", time_counter)
+    return generate_kdf_key(nonce_key, HUBBLE_AES_NONCE_SIZE, "Nonce", counter)
+
+
+def get_encryption_key(master_key: bytes, time_counter: int,
+                       counter: int) -> bytes:
+    encryption_key = generate_kdf_key(master_key, HUBBLE_AES_KEY_SIZE,
+                                      "EncryptionKey", time_counter)
+    return generate_kdf_key(encryption_key, HUBBLE_AES_KEY_SIZE, 'Key',
+                            counter)
+
+
+def get_auth_tag(key: bytes, ciphertext: bytes) -> bytes:
+    return CMAC.new(key, ciphertext, AES).digest()[:HUBBLE_AES_TAG_SIZE]
+
+
+def aes_encrypt(key: bytes, nonce_session: bytes, data: bytes):
+    ciphertext = AES.new(key, AES.MODE_CTR,
+                         nonce=nonce_session).encrypt(data)
+    return ciphertext, get_auth_tag(key, ciphertext)
+
+
+def generate_ble_adv(device_id, seq_no, auth_tag, encrypted_payload) -> bytes:
+    if len(encrypted_payload) > 13:
+        raise ValueError('Encrypted Payload is too long.')
+
+    ble_adv = BitArray()
+    protocol_version = 0b000000
+    ble_adv.append(f'uint:6={protocol_version}')
+    ble_adv.append(f'uint:10={seq_no}')
+    ble_adv.append(f'uint:32={device_id}')
+    ble_adv.append(auth_tag)
+    ble_adv.append(encrypted_payload)
+    return ble_adv.tobytes()
+
+
+def time_counter_from_epoch_ms(
+        epoch_ms: int, rotation_sec: int = HUBBLE_ROTATION_PERIOD_SEC) -> int:
+    return epoch_ms // (rotation_sec * 1000)
+
+
+def build_advertisement(master_key: bytes, epoch_ms: int, seq: int,
+                        payload: bytes,
+                        rotation_sec: int = HUBBLE_ROTATION_PERIOD_SEC
+                        ) -> bytes:
+    """Build the full advertisement (incl. the 0xA6 0xFC UUID prefix)."""
+    tc = time_counter_from_epoch_ms(epoch_ms, rotation_sec)
+    device_id = get_device_id(master_key, tc)
+    nonce = get_nonce(master_key, tc, seq)
+    enc_key = get_encryption_key(master_key, tc, seq)
+    ciphertext, tag = aes_encrypt(enc_key, nonce, payload)
+    return HUBBLE_UUID_PREFIX + generate_ble_adv(device_id, seq, tag,
+                                                 ciphertext)
+
+
+def decrypt_advertisement(master_key: bytes, adv: bytes, epoch_ms: int,
+                          rotation_sec: int = HUBBLE_ROTATION_PERIOD_SEC):
+    """Decrypt/verify an advertisement. Returns (device_id, seq, payload).
+
+    Raises ValueError on a UUID-prefix, device-id, or auth-tag mismatch.
+    """
+    if adv[:2] != HUBBLE_UUID_PREFIX:
+        raise ValueError('Bad UUID prefix')
+    body = adv[2:]
+    version = body[0] >> 2
+    if version != 0:
+        raise ValueError(f'Unexpected protocol version {version}')
+    seq = ((body[0] & 0x03) << 8) | body[1]
+    device_id = int.from_bytes(body[2:6], byteorder='big')
+    tag = body[6:10]
+    ciphertext = body[10:]
+
+    tc = time_counter_from_epoch_ms(epoch_ms, rotation_sec)
+    if device_id != get_device_id(master_key, tc):
+        raise ValueError('Device ID mismatch')
+    enc_key = get_encryption_key(master_key, tc, seq)
+    if get_auth_tag(enc_key, ciphertext) != tag:
+        raise ValueError('Auth tag mismatch')
+    nonce = get_nonce(master_key, tc, seq)
+    payload = AES.new(enc_key, AES.MODE_CTR, nonce=nonce).decrypt(ciphertext)
+    return device_id, seq, payload

--- a/west.yml
+++ b/west.yml
@@ -5,6 +5,8 @@ manifest:
   remotes:
     - name: zephyrproject-rtos
       url-base: https://github.com/zephyrproject-rtos
+    - name: buckleypaul
+      url-base: https://github.com/buckleypaul
 
   projects:
     - name: zephyr
@@ -12,6 +14,14 @@ manifest:
       revision: v4.4.0
       import: true
       west-commands: scripts/west-commands.yml
+    - name: riglink
+      remote: buckleypaul
+      revision: main
+      path: modules/lib/riglink
+    - name: jcon
+      remote: buckleypaul
+      revision: main
+      path: modules/lib/jcon
 
   self:
     path: modules/lib/hubblenetwork-sdk


### PR DESCRIPTION
## Summary

- Factors Hubble reference crypto out of `tools/ble-adv.py` into a reusable `tools/hubble_ref_crypto.py` module
- Adds a Zephyr firmware target (`tests/riglink/`) that exposes riglink RIG commands for initialising the SDK and retrieving BLE advertisements
- Adds a Python test suite (`tests/riglink/python/`) that connects to the device over pseudotty (native_sim) or UART (nrf52840dk), drives it via riglink, and validates advertisement payloads against the reference crypto implementation
- Supports `native_sim/native/64` for CI and `nrf52840dk_nrf52840` for hardware-in-the-loop testing
- Adds `riglink` and `jcon` to the west manifest

## Test plan

- [ ] Build firmware for native_sim: `west build -b native_sim/native/64 tests/riglink`
- [ ] Run pytest against native_sim: `pytest tests/riglink/python/ --riglink-port <pseudotty>`
- [ ] Build and flash nrf52840dk firmware, run pytest with `--riglink-port /dev/ttyACM0`
- [ ] Confirm `test_ble.py` passes (BLE advertisement round-trip)
- [ ] Confirm `test_reference.py` passes (reference crypto validation)