### PR TITLE
api: sat: rename hubble_sat_packet_send to hubble_sat_broadcast

### DIFF
--- a/docs/architecture/project-organization.rst
+++ b/docs/architecture/project-organization.rst
@@ -178,7 +178,7 @@ Use this namespace for stable application APIs and SDK-wide constants. Examples:
   ``hubble_key_set()`` from ``hubble.h``;
 * ``hubble_ble_advertise_get()`` and
   ``hubble_ble_advertise_expiration_get()`` from ``ble.h``;
-* ``hubble_sat_packet_send()`` from ``sat.h``;
+* ``hubble_sat_broadcast()`` from ``sat.h``;
 * satellite packet, pass prediction, and DTM helpers under ``include/hubble/sat``.
 
 When adding a public API, place its declaration in ``include/hubble``, add
@@ -203,7 +203,7 @@ Symbols with ``_port_`` in the name are implemented by a port or board
 layer and called by common SDK code — for example
 ``hubble_sat_port_init()`` and ``hubble_sat_port_packet_send()``. The
 ``_port_`` suffix implies there is an equivalent common function that
-shares code across all ports, for example ``hubble_sat_packet_send()``.
+shares code across all ports, for example ``hubble_sat_broadcast()``.
 
 Not every port contract carries ``_port_`` in its
 name. ``hubble_uptime_get()``, ``hubble_log()``, and

--- a/include/hubble/sat.h
+++ b/include/hubble/sat.h
@@ -66,13 +66,16 @@ enum hubble_sat_transmission_mode {
 };
 
 /**
- * @brief Transmit a packet using the Hubble satellite communication system.
+ * @brief Broadcast a packet using the Hubble satellite communication system.
  *
- * This function sends a packet over the satellite communication channel.
- * The packet must be properly formatted and adhere to the Hubble protocol.
+ * This function broadcasts a packet over the satellite communication channel.
+ * Depending on @p mode, the packet is transmitted multiple times (see
+ * @ref hubble_sat_transmission_mode) to increase the likelihood of reception
+ * by a satellite. The packet must be properly formatted and adhere to the
+ * Hubble protocol.
  *
- * @note This function is blocking: it does not return until the transmission
- *       period has completed.
+ * @note This function is blocking: it does not return until the entire
+ *       transmission period, including all retransmissions, has completed.
  *
  * @param packet A pointer to the @ref hubble_sat_packet structure containing
  *               the data to be transmitted.
@@ -84,8 +87,8 @@ enum hubble_sat_transmission_mode {
  *          any validation on the packet structure. It is the caller's
  *          responsibility to ensure the packet is correctly formatted.
  */
-int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
-			   enum hubble_sat_transmission_mode mode);
+int hubble_sat_broadcast(const struct hubble_sat_packet *packet,
+			 enum hubble_sat_transmission_mode mode);
 
 /**
  * @}

--- a/include/hubble/sat/dtm.h
+++ b/include/hubble/sat/dtm.h
@@ -46,7 +46,7 @@ enum hubble_sat_dtm_packet_type {
  * Transmits a single DTM packet of the given type on the specified channel.
  *
  * @note channel equals -1 means regular transmission as it is done with
- * @ref hubble_sat_packet_send
+ * @ref hubble_sat_broadcast
  *
  * @param type    Packet payload pattern to use.
  * @param channel RF channel to transmit on. -1 to hop between channels.

--- a/samples/esp-idf/sat-continuous/main/main.c
+++ b/samples/esp-idf/sat-continuous/main/main.c
@@ -88,7 +88,7 @@ void app_main(void)
 			return;
 		}
 
-		err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
+		err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
 		if (err != 0) {
 			ESP_LOGE(APP_TAG,
 				 "Failed to transmit packet, error: %d", err);

--- a/samples/freertos/ti/sat-continuous/src/main.c
+++ b/samples/freertos/ti/sat-continuous/src/main.c
@@ -44,8 +44,8 @@ void *mainThread(void *arg0)
 			return NULL;
 		}
 
-		ret = hubble_sat_packet_send(&packet,
-					     HUBBLE_SAT_RELIABILITY_NORMAL);
+		ret = hubble_sat_broadcast(&packet,
+					   HUBBLE_SAT_RELIABILITY_NORMAL);
 		if (ret != 0) {
 			/* TODO: Call Error Handler */
 			return NULL;

--- a/samples/zephyr/sat-continuous/src/main.c
+++ b/samples/zephyr/sat-continuous/src/main.c
@@ -65,7 +65,7 @@ int main(void)
 			goto end;
 		}
 
-		err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
+		err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
 		if (err != 0) {
 			LOG_ERR("Failed to transmit packet");
 			goto end;

--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -114,8 +114,8 @@ int hubble_internal_sat_init(void)
 	return 0;
 }
 
-int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
-			   enum hubble_sat_transmission_mode mode)
+int hubble_sat_broadcast(const struct hubble_sat_packet *packet,
+			 enum hubble_sat_transmission_mode mode)
 {
 	int ret;
 	uint8_t interval_s, retries;

--- a/tests/zephyr/sat-api/src/main.c
+++ b/tests/zephyr/sat-api/src/main.c
@@ -166,31 +166,31 @@ ZTEST(sat_test, test_profile)
 	zassert_ok(err);
 
 	/* Sanity check. Invalid packet */
-	err = hubble_sat_packet_send(NULL, HUBBLE_SAT_RELIABILITY_NORMAL);
+	err = hubble_sat_broadcast(NULL, HUBBLE_SAT_RELIABILITY_NORMAL);
 	zassert_not_ok(err);
 
 	/* Sanity check. Invalid reliability */
 	_transmission_count = 16U;
-	err = hubble_sat_packet_send(&pkt, 255);
+	err = hubble_sat_broadcast(&pkt, 255);
 	zassert_not_ok(err);
 	/* Checking no transmissions happened. */
 	zassert_equal(16U, _transmission_count);
 
 	/* Test no reliability. One time transmission */
 	_transmission_count = 1U;
-	err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
+	err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
 	zassert_ok(err);
 	zassert_equal(0, _transmission_count);
 
 	/* Test normal reliability  - 8u */
 	_transmission_count = 8U;
-	err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
+	err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL);
 	zassert_ok(err);
 	zassert_equal(0, _transmission_count);
 
 	/* Test high reliability  - 16u */
 	_transmission_count = 16U;
-	err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_HIGH);
+	err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_HIGH);
 	zassert_ok(err);
 	zassert_equal(0, _transmission_count);
 }
@@ -207,10 +207,10 @@ ZTEST(sat_test, test_channel_hopping)
 	err = hubble_sat_packet_get(&pkt, NULL, 0);
 	zassert_ok(err);
 
-	err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
+	err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
 	zassert_ok(err);
 
-	err = hubble_sat_packet_send(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
+	err = hubble_sat_broadcast(&pkt, HUBBLE_SAT_RELIABILITY_NONE);
 	zassert_ok(err);
 
 	_test_hopping = false;


### PR DESCRIPTION
The name "send" implied a single, point-to-point transmission of one packet. In reality the call emits the packet repeatedly into a broadcast medium with no acknowledgement: depending on the reliability mode the same packet is transmitted up to 8 or 16 times (plus drift-compensation retries), and it is never directed at a specific receiver. "broadcast" sets the right expectation that this is a fire-and-forget, multi-shot operation that blocks for the whole transmission period, so callers budget power and timing accordingly rather than assuming a quick send.

The "packet" qualifier is dropped: it added no information the hubble_sat_packet argument type does not already convey, and the shorter hubble_sat_broadcast reads as the verb for the whole satellite channel.