### PR TITLE
sat: Add hubble_sat_packet_send_pass

### DIFF
--- a/docs/satellite/reliability.rst
+++ b/docs/satellite/reliability.rst
@@ -3,10 +3,11 @@
 Reliability and Power Consumption
 #################################
 
-The reliability mode passed to :c:func:`hubble_sat_packet_send` controls how
-many times the SDK asks the platform radio port to send the same packet and how
-far apart those transmissions are spaced. It is the primary trade-off between
-delivery probability and energy use.
+The reliability mode passed to :c:func:`hubble_sat_packet_send` and
+:c:func:`hubble_sat_packet_pass_send` controls how many times the SDK asks the
+platform radio port to send the same packet and how far apart those
+transmissions are spaced. It is the primary trade-off between delivery
+probability and energy use.
 
 Reliability Modes
 *****************
@@ -59,3 +60,46 @@ For battery-powered products, the most power-efficient design is usually a
 pass-predicted workflow: sleep or use low-power BLE between passes, wake before
 ``pass.start``, transmit with the lowest reliability mode that meets the product
 delivery requirement, then return to the low-power state.
+
+Pass-Adaptive Transmission
+***************************
+
+:c:func:`hubble_sat_packet_pass_send` sends a packet using a
+:c:struct:`hubble_sat_pass_info` window instead of the fixed baselines in the
+table above. Rather than always transmitting the mode's baseline number of
+times, it derives the retry count from ``pass.duration`` so the packet is
+retransmitted as many times as will fit while the satellite is overhead.
+
+.. code-block:: c
+
+   struct hubble_sat_pass_info pass;
+
+   err = hubble_sat_next_pass_region_get(hubble_time_get(), &region, &pass);
+   if (err != 0) {
+           return err;
+   }
+
+   err = hubble_sat_packet_pass_send(&packet, HUBBLE_SAT_RELIABILITY_NORMAL,
+                                     &pass);
+   if (err != 0) {
+           return err;
+   }
+
+* **Required for a region pass.** A pass obtained from
+  :c:func:`hubble_sat_next_pass_region_get` has no single point of reference
+  the fixed baselines were tuned for, so :c:func:`hubble_sat_packet_send` has
+  no way to fit its retries to that window. Use
+  :c:func:`hubble_sat_packet_pass_send` whenever the pass came from a region
+  query.
+* **Also usable for a single-point pass.** A pass from
+  :c:func:`hubble_sat_next_pass_get` works too — in that case
+  :c:func:`hubble_sat_packet_pass_send` is a drop-in alternative to
+  :c:func:`hubble_sat_packet_send` that adapts retries to that specific pass's
+  duration instead of using the mode's fixed baseline.
+* **``HUBBLE_SAT_RELIABILITY_NONE`` is invalid.** This function requires a
+  mode that retries (``HUBBLE_SAT_RELIABILITY_NORMAL`` or
+  ``HUBBLE_SAT_RELIABILITY_HIGH``); passing ``HUBBLE_SAT_RELIABILITY_NONE``, a
+  NULL ``packet``, or a NULL ``pass`` returns ``-EINVAL``.
+
+See :ref:`hubble_pass_prediction_best_practices` for how to obtain a
+:c:struct:`hubble_sat_pass_info`.

--- a/include/hubble/sat.h
+++ b/include/hubble/sat.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <hubble/sat/packet.h>
+#include <hubble/sat/pass_prediction.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -86,6 +87,34 @@ enum hubble_sat_transmission_mode {
  */
 int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
 			   enum hubble_sat_transmission_mode mode);
+
+/**
+ * @brief Transmit a packet during a predicted satellite pass.
+ *
+ * This function sends a packet over the satellite communication channel,
+ * for the duration of time provided in the satellite pass info.
+ * The pass duration is used to derive the number of retransmissions,
+ * so the packet is transmitted as many times as possible while the satellite
+ * is overhead.
+ *
+ * @note This function is blocking: it does not return until the transmission
+ *       window defined by the pass has completed.
+ *
+ * @param packet A pointer to the @ref hubble_sat_packet structure containing
+ *               the data to be transmitted.
+ * @param mode   Desired reliability for the transmission.
+ * @param pass   A pointer to the @ref hubble_sat_pass_info structure describing
+ *               the satellite pass window.
+ *
+ * @return 0 on successful transmission, or a negative error code on failure.
+ *
+ * @warning This function checks if the packet and pass are NULL but does not
+ *          perform any validation on these structures. It is the caller's
+ *          responsibility to ensure they are correctly formatted.
+ */
+int hubble_sat_packet_send_pass(const struct hubble_sat_packet *packet,
+				enum hubble_sat_transmission_mode mode,
+				const struct hubble_sat_pass_info *pass);
 
 /**
  * @}

--- a/include/hubble/sat.h
+++ b/include/hubble/sat.h
@@ -95,17 +95,31 @@ int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
  * @note This function is blocking: it does not return until the transmission
  *       window defined by the pass has completed.
  *
+ * @note This function must be used for a pass over a region, i.e. when
+ *       @p pass was obtained from @ref hubble_sat_next_pass_region_get(),
+ *       since @ref hubble_sat_packet_send() has no way to fit its retries
+ *       to a specific region pass window. It can also be used for a
+ *       regular pass obtained from @ref hubble_sat_next_pass_get(),
+ *       in which case it is a drop-in alternative to @ref
+ *       hubble_sat_packet_send() that adapts the number of retries to
+ *       that pass's duration instead of using the fixed baseline for
+ *       @p mode.
+ *
  * @param packet A pointer to the @ref hubble_sat_packet structure containing
  *               the data to be transmitted.
  * @param mode   Desired reliability for the transmission.
  * @param pass   A pointer to the @ref hubble_sat_pass_info structure describing
  *               the satellite pass window.
  *
- * @return 0 on successful transmission, or a negative error code on failure.
+ * @retval 0 on successful transmission
+ * @retval -EINVAL if @p packet or @p pass is NULL, or if @p mode is
+ *         @ref HUBBLE_SAT_RELIABILITY_NONE.
  *
- * @warning This function checks if the packet and pass are NULL but does not
- *          perform any validation on these structures. It is the caller's
- *          responsibility to ensure they are correctly formatted.
+ * @warning @ref HUBBLE_SAT_RELIABILITY_NONE is not valid for this function.
+ *          A single-shot transmission does not provide coverage across a
+ *          satellite pass window, so this function requires a mode that
+ *          retries (@ref HUBBLE_SAT_RELIABILITY_NORMAL or
+ *          @ref HUBBLE_SAT_RELIABILITY_HIGH).
  */
 int hubble_sat_packet_pass_send(const struct hubble_sat_packet *packet,
 				enum hubble_sat_transmission_mode mode,

--- a/include/hubble/sat.h
+++ b/include/hubble/sat.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <hubble/sat/packet.h>
+#include <hubble/sat/pass_prediction.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,6 +82,34 @@ enum hubble_sat_transmission_mode {
  */
 int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
 			   enum hubble_sat_transmission_mode mode);
+
+/**
+ * @brief Transmit a packet during a predicted satellite pass.
+ *
+ * This function sends a packet over the satellite communication channel,
+ * for the duration of time provided in the satellite pass info.
+ * The pass duration is used to derive the number of retransmissions,
+ * so the packet is transmitted as many times as possible while the satellite
+ * is overhead.
+ *
+ * @note This function is blocking: it does not return until the transmission
+ *       window defined by the pass has completed.
+ *
+ * @param packet A pointer to the @ref hubble_sat_packet structure containing
+ *               the data to be transmitted.
+ * @param mode   Desired reliability for the transmission.
+ * @param pass   A pointer to the @ref hubble_sat_pass_info structure describing
+ *               the satellite pass window.
+ *
+ * @return 0 on successful transmission, or a negative error code on failure.
+ *
+ * @warning This function checks if the packet and pass are NULL but does not
+ *          perform any validation on these structures. It is the caller's
+ *          responsibility to ensure they are correctly formatted.
+ */
+int hubble_sat_packet_pass_send(const struct hubble_sat_packet *packet,
+				enum hubble_sat_transmission_mode mode,
+				const struct hubble_sat_pass_info *pass);
 
 /**
  * @}

--- a/include/hubble/sat/pass_prediction.h
+++ b/include/hubble/sat/pass_prediction.h
@@ -154,14 +154,11 @@ int hubble_sat_next_pass_get(uint64_t t, const struct hubble_sat_device_pos *pos
  * rectangular geographic region defined by latitude and longitude
  * bounds, based on satellites orbital parameters.
  *
- * @experimental
- *
  * @param t Current time or the time to start the calculation (milliseconds since Unix epoch).
  * @param region Pointer to the geographic region definition.
  * @param pass The next satellite pass in case of success.
  * @return 0 on success or a negative value in case of error.
  */
-HUBBLE_EXPERIMENTAL
 int hubble_sat_next_pass_region_get(
 	uint64_t t, const struct hubble_sat_device_region *region,
 	struct hubble_sat_pass_info *pass);

--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -150,6 +150,44 @@ int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
 	return 0;
 }
 
+int hubble_sat_packet_send_pass(const struct hubble_sat_packet *packet,
+				enum hubble_sat_transmission_mode mode,
+				const struct hubble_sat_pass_info *pass)
+{
+	int ret;
+	uint8_t interval_s, retries;
+
+	if (packet == NULL || pass == NULL) {
+		return -EINVAL;
+	}
+
+	ret = _transmission_params_get(mode, &retries, &interval_s);
+	if (ret < 0) {
+		HUBBLE_LOG_WARNING("Invalid mode given");
+		return ret;
+	}
+
+	if (interval_s > 0U) {
+		retries = (uint8_t)HUBBLE_MIN(
+			UINT8_MAX,
+			HUBBLE_MAX(1U, pass->duration / (1000U * interval_s)));
+	}
+
+	HUBBLE_LOG_DEBUG("Number of retries: %u - interval: %u seconds",
+			 retries, interval_s);
+
+	ret = hubble_sat_port_packet_send(packet, retries, interval_s);
+	if (ret < 0) {
+		HUBBLE_LOG_WARNING(
+			"Hubble Satellite packet transmission failed");
+		return ret;
+	}
+
+	HUBBLE_LOG_INFO("Hubble Satellite packet sent");
+
+	return 0;
+}
+
 #ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
 
 int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,

--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -157,7 +157,8 @@ int hubble_sat_packet_pass_send(const struct hubble_sat_packet *packet,
 	int ret;
 	uint8_t interval_s, retries;
 
-	if (packet == NULL || pass == NULL) {
+	if (packet == NULL || pass == NULL ||
+	    mode == HUBBLE_SAT_RELIABILITY_NONE) {
 		return -EINVAL;
 	}
 
@@ -170,7 +171,8 @@ int hubble_sat_packet_pass_send(const struct hubble_sat_packet *packet,
 	if (interval_s > 0U) {
 		retries = (uint8_t)HUBBLE_MIN(
 			UINT8_MAX,
-			HUBBLE_MAX(1U, pass->duration / (1000U * interval_s)));
+			HUBBLE_MAX(1U, pass->duration / (HUBBLE_MSEC_PER_SEC *
+							 interval_s)));
 	}
 
 	HUBBLE_LOG_DEBUG("Number of retries: %u - interval: %u seconds",

--- a/src/hubble_sat.c
+++ b/src/hubble_sat.c
@@ -150,6 +150,44 @@ int hubble_sat_packet_send(const struct hubble_sat_packet *packet,
 	return 0;
 }
 
+int hubble_sat_packet_pass_send(const struct hubble_sat_packet *packet,
+				enum hubble_sat_transmission_mode mode,
+				const struct hubble_sat_pass_info *pass)
+{
+	int ret;
+	uint8_t interval_s, retries;
+
+	if (packet == NULL || pass == NULL) {
+		return -EINVAL;
+	}
+
+	ret = _transmission_params_get(mode, &retries, &interval_s);
+	if (ret < 0) {
+		HUBBLE_LOG_WARNING("Invalid mode given");
+		return ret;
+	}
+
+	if (interval_s > 0U) {
+		retries = (uint8_t)HUBBLE_MIN(
+			UINT8_MAX,
+			HUBBLE_MAX(1U, pass->duration / (1000U * interval_s)));
+	}
+
+	HUBBLE_LOG_DEBUG("Number of retries: %u - interval: %u seconds",
+			 retries, interval_s);
+
+	ret = hubble_sat_port_packet_send(packet, retries, interval_s);
+	if (ret < 0) {
+		HUBBLE_LOG_WARNING(
+			"Hubble Satellite packet transmission failed");
+		return ret;
+	}
+
+	HUBBLE_LOG_INFO("Hubble Satellite packet sent");
+
+	return 0;
+}
+
 #ifdef CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE
 
 int hubble_sat_dtm_packet_send(enum hubble_sat_dtm_packet_type type,

--- a/tests/zephyr/sat-api/src/main.c
+++ b/tests/zephyr/sat-api/src/main.c
@@ -224,6 +224,72 @@ ZTEST(sat_test, test_channel_hopping)
 	_test_hopping = false;
 }
 
+ZTEST(sat_test, test_packet_send_from_pass)
+{
+	int err;
+	struct hubble_sat_packet pkt;
+	struct hubble_sat_pass_info pass = {0};
+
+	err = hubble_sat_packet_get(&pkt, NULL, 0);
+	zassert_ok(err);
+
+	/* NULL packet must fail */
+	err = hubble_sat_packet_send_pass(NULL, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_not_ok(err);
+
+	/* NULL pass must fail */
+	err = hubble_sat_packet_send_pass(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  NULL);
+	zassert_not_ok(err);
+
+	/* Invalid mode must fail without transmitting */
+	_transmission_count = 8U;
+	err = hubble_sat_packet_send_pass(&pkt, 255, &pass);
+	zassert_not_ok(err);
+	zassert_equal(8U, _transmission_count);
+
+	/* RELIABILITY_NONE: always 1 transmission regardless of pass duration */
+	pass.duration = 160000U;
+	_transmission_count = 1U;
+	err = hubble_sat_packet_send_pass(&pkt, HUBBLE_SAT_RELIABILITY_NONE,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* RELIABILITY_NORMAL (20s interval): 160s pass -> 8 retries */
+	pass.duration = 160000U;
+	_transmission_count = 8U;
+	err = hubble_sat_packet_send_pass(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* RELIABILITY_HIGH (10s interval): 160s pass -> 16 retries */
+	pass.duration = 160000U;
+	_transmission_count = 16U;
+	err = hubble_sat_packet_send_pass(&pkt, HUBBLE_SAT_RELIABILITY_HIGH,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* Shorter pass: 40s with NORMAL -> 2 retries, not the fixed 8 */
+	pass.duration = 40000U;
+	_transmission_count = 2U;
+	err = hubble_sat_packet_send_pass(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* Pass shorter than one interval -> minimum 1 retry */
+	pass.duration = 5000U;
+	_transmission_count = 1U;
+	err = hubble_sat_packet_send_pass(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+}
+
 static void *sat_test_setup(void)
 {
 	int err;

--- a/tests/zephyr/sat-api/src/main.c
+++ b/tests/zephyr/sat-api/src/main.c
@@ -224,6 +224,72 @@ ZTEST(sat_test, test_channel_hopping)
 	_test_hopping = false;
 }
 
+ZTEST(sat_test, test_packet_send_from_pass)
+{
+	int err;
+	struct hubble_sat_packet pkt;
+	struct hubble_sat_pass_info pass = {0};
+
+	err = hubble_sat_packet_get(&pkt, NULL, 0);
+	zassert_ok(err);
+
+	/* NULL packet must fail */
+	err = hubble_sat_packet_pass_send(NULL, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_not_ok(err);
+
+	/* NULL pass must fail */
+	err = hubble_sat_packet_pass_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  NULL);
+	zassert_not_ok(err);
+
+	/* Invalid mode must fail without transmitting */
+	_transmission_count = 8U;
+	err = hubble_sat_packet_pass_send(&pkt, 255, &pass);
+	zassert_not_ok(err);
+	zassert_equal(8U, _transmission_count);
+
+	/* RELIABILITY_NONE is invalid: a single shot does not cover a pass */
+	pass.duration = 160000U;
+	_transmission_count = 1U;
+	err = hubble_sat_packet_pass_send(&pkt, HUBBLE_SAT_RELIABILITY_NONE,
+					  &pass);
+	zassert_not_ok(err);
+	zassert_equal(1U, _transmission_count);
+
+	/* RELIABILITY_NORMAL (20s interval): 160s pass -> 8 retries */
+	pass.duration = 160000U;
+	_transmission_count = 8U;
+	err = hubble_sat_packet_pass_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* RELIABILITY_HIGH (10s interval): 160s pass -> 16 retries */
+	pass.duration = 160000U;
+	_transmission_count = 16U;
+	err = hubble_sat_packet_pass_send(&pkt, HUBBLE_SAT_RELIABILITY_HIGH,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* Shorter pass: 40s with NORMAL -> 2 retries, not the fixed 8 */
+	pass.duration = 40000U;
+	_transmission_count = 2U;
+	err = hubble_sat_packet_pass_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+
+	/* Pass shorter than one interval -> minimum 1 retry */
+	pass.duration = 5000U;
+	_transmission_count = 1U;
+	err = hubble_sat_packet_pass_send(&pkt, HUBBLE_SAT_RELIABILITY_NORMAL,
+					  &pass);
+	zassert_ok(err);
+	zassert_equal(0, _transmission_count);
+}
+
 static void *sat_test_setup(void)
 {
 	int err;


### PR DESCRIPTION
Add `hubble_sat_packet_send_pass()` API that accepts a `hubble_sat_pass_info` to drive the transmission window instead of relying on the fixed retry counts defined by the transmission mode 

