### PR TITLE
boards: silabs: update channel spacing

### DIFF
--- a/port/zephyr/boards/silabs/efr32/radio.c
+++ b/port/zephyr/boards/silabs/efr32/radio.c
@@ -18,7 +18,7 @@
 
 #include "rail_config.h"
 
-/* EFR32 step size = 72 - 74 Hz */
+/* xG24 step size = 74.3865966796875 Hz */
 #define EFR32_STEP_SCALE(step) (step * 4)
 #define MAX_POWER_DDBM         200 /* DBm = 10 * dBm */
 

--- a/port/zephyr/boards/silabs/efr32/radio.c
+++ b/port/zephyr/boards/silabs/efr32/radio.c
@@ -179,6 +179,9 @@ static int _rail_radio_init(void)
 		return _sl_status_to_errno(status);
 	}
 
+	sl_rail_util_pa_init();
+	sl_rail_util_pa_post_init(_rail_handle, pa_mode);
+
 	/* Config calibration settings */
 	status = sl_rail_config_cal(_rail_handle, SL_RAIL_CAL_ALL);
 	if (status) {
@@ -219,9 +222,6 @@ static int _rail_radio_init(void)
 	if (status != SL_RAIL_STATUS_NO_ERROR) {
 		return _sl_status_to_errno(status);
 	}
-
-	sl_rail_util_pa_init();
-	sl_rail_util_pa_post_init(_rail_handle, pa_mode);
 
 	return _sl_status_to_errno(status);
 }

--- a/port/zephyr/boards/silabs/efr32/xg24/radio_settings.radioconf
+++ b/port/zephyr/boards/silabs/efr32/xg24/radio_settings.radioconf
@@ -21,11 +21,11 @@
       <profile_inputs>
         <input>
           <key>base_frequency_hz</key>
-          <value>2482169300</value>
+          <value>2482140700</value>
         </input>
         <input>
           <key>channel_spacing_hz</key>
-          <value>25752</value>
+          <value>25887</value>
         </input>
         <input>
           <key>xtal_frequency_hz</key>

--- a/port/zephyr/boards/silabs/efr32/xg24/rail_config_v1.c
+++ b/port/zephyr/boards/silabs/efr32/xg24/rail_config_v1.c
@@ -115,7 +115,7 @@ static const uint32_t phyInfo[] = {
 	(uint32_t)NULL,
 	0UL,
 	0UL,
-	999989UL,
+	999977UL,
 	(uint32_t)NULL,
 	(uint32_t)NULL,
 	(uint32_t)NULL,
@@ -257,7 +257,7 @@ const uint32_t Hubble_Protocol_Configuration_modemConfigBase[] = {
 	/*    4130 */ 0x078304FFUL,
 	/*    4134 */ 0x03FF1388UL,
 	/*    4138 */ 0xF00A20BCUL,
-	/*    413C */ 0x00515C59UL,
+	/*    413C */ 0x00515C5AUL,
 	/*    4140 */ 0x40A56503UL,
 	/*    4144 */ 0x55F68D00UL,
 	/*    4148 */ 0x42A832A5UL,
@@ -407,8 +407,8 @@ const uint32_t Hubble_Protocol_Configuration_modemConfigBase[] = {
 const RAIL_ChannelConfigEntry_t Hubble_Protocol_Configuration_channels[] = {
 	{
 		.phyConfigDeltaAdd = NULL,
-		.baseFrequency = 2482169300,
-		.channelSpacing = 25752,
+		.baseFrequency = 2482140700,
+		.channelSpacing = 25887,
 		.physicalChannelOffset = 0,
 		.channelNumberStart = 0,
 		.channelNumberEnd = 18,


### PR DESCRIPTION
- Update channel spacing to use the full synthesizer resolution precision instead of the integer rounding.
- Update the order of PA init. This could be in a separate PR, but since it's minor, I just want to get this in along with this PR as well. The order does not matter for older version, but it does for SiSDK v2026.6.1 (with RAIL 3.0) and beyond. 