### PR TITLE
ci: update CI trigger to include path that affects each CI tests

### DIFF
--- a/.github/workflows/build-samples-esp-idf.yaml
+++ b/.github/workflows/build-samples-esp-idf.yaml
@@ -5,8 +5,11 @@ on:
     branches: ["**"]
     paths:
       - "include/**"
+      - "port/esp-idf/**"
+      - "port/freertos/**"
       - "src/**"
       - "samples/esp-idf/**"
+      - "tools/ci/esp-idf-build-manifest.yaml"
       - ".github/workflows/build-samples-esp-idf.yaml"
 
   workflow_dispatch: {}

--- a/.github/workflows/build-samples-ti.yaml
+++ b/.github/workflows/build-samples-ti.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["**"]
     paths:
       - "include/**"
+      - "port/freertos/**"
       - "src/**"
       - "samples/freertos/ti/**"
       - ".github/workflows/build-samples-ti.yaml"

--- a/.github/workflows/ncs-tests.yaml
+++ b/.github/workflows/ncs-tests.yaml
@@ -5,9 +5,13 @@ on:
     branches: ["**"]
     paths:
       - "include/**"
+      - "port/zephyr/**"
       - "src/**"
       - "samples/zephyr/**"
       - "tests/zephyr/**"
+      - "zephyr/module.yml"
+      - "west-ncs.yml"
+      - "tools/ci/twister-quarantine.yaml"
       - ".github/workflows/ncs-tests.yaml"
 
   workflow_dispatch:

--- a/.github/workflows/zephyr-tests.yaml
+++ b/.github/workflows/zephyr-tests.yaml
@@ -5,9 +5,13 @@ on:
     branches: ["**"]
     paths:
       - "include/**"
+      - "port/zephyr/**"
       - "src/**"
       - "samples/zephyr/**"
       - "tests/zephyr/**"
+      - "zephyr/module.yml"
+      - "west.yml"
+      - "tools/ci/twister-quarantine.yaml"
       - ".github/workflows/zephyr-tests.yaml"
 
   workflow_dispatch:


### PR DESCRIPTION
Update the CI build for each port to include paths to source code that would benefit from a CI rebuild to check for issues.