### PR TITLE
docs: integration guide: update ncs and spell out acronyms

### DIFF
--- a/docs/integration_guides/common/prerequisites.rst
+++ b/docs/integration_guides/common/prerequisites.rst
@@ -7,9 +7,10 @@ Prerequisites
 
 Before starting, ensure you have the following:
 
-* **A supported development kit or custom board** with a PA or FEM capable of
-  at least +20 dBm transmit output power. The Hubble satellite link budget
-  requires this minimum output to reach the network reliably.
+* **A supported development kit or custom board** with a power amplifier (PA)
+  or front-end module (FEM) capable of at least +20 dBm transmit output power.
+  The Hubble satellite link budget requires this minimum output to reach the
+  network reliably.
 * **An antenna tuned to the Hubble satellite frequency band**, connected to
   the RF output of the PA or FEM.
 * **A Hubble account and API key** to fetch ephemeris data for pass prediction.

--- a/docs/integration_guides/ncs/index.rst
+++ b/docs/integration_guides/ncs/index.rst
@@ -27,21 +27,25 @@ Nordic nRF52, nRF53, and nRF54 Series SoCs are supported. The SDK includes
 board API implementations for the following development kits out of the box:
 
 .. list-table::
-   :widths: 50 25 25
+   :widths: 20 25 15 40
    :header-rows: 1
 
    * - Board
      - Target
      - SoC Family
+     - Notes
    * - nRF21540 DK
      - ``nrf21540dk/nrf52840``
      - nRF52
+     - nRF52840 max +8 dBm; on-board nRF21540 FEM reaches +20 dBm
    * - Nordic Thingy:53
      - ``thingy53/nrf5340/cpunet``
      - nRF53
+     - nRF5340 max +3 dBm; on-board nRF21540 FEM reaches +20 dBm
    * - nRF54L15 DK
      - ``nrf54l15dk/nrf54l15/cpuapp``
      - nRF54
+     - nRF54L15 max +8 dBm; external amplifier required to reach +20 dBm
 
 For custom boards, refer to the :ref:`board bring-up <ncs_sat_board_bringup>`
 section.


### PR DESCRIPTION
- Update NCS integration guide to include the Notes column about power of each dev kit.
- Spell out the PA and FEM acronyms for first time reader.

New table looks like this:

<img width="858" height="287" alt="Screenshot 2026-08-27 at 8 18 37 AM" src="https://github.com/user-attachments/assets/c6155380-bd2d-49ea-8f62-12baddb352e8" />
