### PR TITLE
sat: esp-idf: remove rftest dependency

### DIFF
--- a/port/esp-idf/hubblenetwork-sdk/Kconfig
+++ b/port/esp-idf/hubblenetwork-sdk/Kconfig
@@ -28,7 +28,6 @@ endchoice
 
 menuconfig HUBBLE_SAT_NETWORK
 	   bool "Hubble Satellite Network Library"
-	   select ESP_PHY_ENABLE_CERT_TEST
 	   help
 		Enable library for communication with Hubble network.
 

--- a/port/esp-idf/hubblenetwork-sdk/boards/esp32c6/radio.c
+++ b/port/esp-idf/hubblenetwork-sdk/boards/esp32c6/radio.c
@@ -247,7 +247,6 @@ int hubble_sat_board_init(void)
 		return -EAGAIN;
 	}
 
-	esp_phy_rftest_init();
 	return 0;
 }
 
@@ -258,15 +257,12 @@ int hubble_sat_board_enable(void)
 		return ret;
 	}
 
-	esp_phy_rftest_config(1);
 	phy_set_step_01k(true);
-
 	return 0;
 }
 
 int hubble_sat_board_disable(void)
 {
-	esp_phy_rftest_config(0);
 	phy_set_step_01k(false);
 	return _timer_disable();
 }

--- a/samples/esp-idf/sat-continuous/main/CMakeLists.txt
+++ b/samples/esp-idf/sat-continuous/main/CMakeLists.txt
@@ -4,5 +4,5 @@
 set(SOURCES "main.c")
 
 idf_component_register(SRCS ${SOURCES}
-		       PRIV_REQUIRES mbedtls hubblenetwork-sdk
+		       PRIV_REQUIRES bt mbedtls nvs_flash hubblenetwork-sdk
 		       INCLUDE_DIRS ".")

--- a/samples/esp-idf/sat-continuous/main/main.c
+++ b/samples/esp-idf/sat-continuous/main/main.c
@@ -12,6 +12,8 @@
 
 #include "esp_log.h"
 #include "esp_system.h"
+#include "nvs_flash.h"
+#include "nimble/nimble_port.h"
 
 #include "mbedtls/base64.h"
 
@@ -44,6 +46,22 @@ void app_main(void)
 		ESP_LOGD(APP_TAG, "Device key decoded (%zu bytes):", outlen);
 		ESP_LOG_BUFFER_HEX_LEVEL(APP_TAG, _hubble_key, outlen,
 					 ESP_LOG_DEBUG);
+	}
+
+	/* Initialize NVS — it is used to store PHY calibration data */
+	err = nvs_flash_init();
+	if (err == ESP_ERR_NVS_NO_FREE_PAGES ||
+	    err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+		ESP_ERROR_CHECK(nvs_flash_erase());
+		err = nvs_flash_init();
+	}
+	ESP_ERROR_CHECK(err);
+
+	/* Init Bluetooth (NimBLE) */
+	err = nimble_port_init();
+	if (err != ESP_OK) {
+		ESP_LOGE(APP_TAG, "Failed to init NimBLE stack, error: %d", err);
+		return;
 	}
 
 	err = hubble_init(0, _hubble_key);

--- a/samples/esp-idf/sat-continuous/sdkconfig.defaults
+++ b/samples/esp-idf/sat-continuous/sdkconfig.defaults
@@ -1,6 +1,11 @@
 # Copyright (c) 2026 Hubble Network, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Bluetooth
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+CONFIG_BT_NIMBLE_50_FEATURE_SUPPORT=n
+
 # Sat dependencies
 CONFIG_HUBBLE_SAT_NETWORK=y
 

--- a/samples/esp-idf/sat-continuous/sdkconfig.defaults
+++ b/samples/esp-idf/sat-continuous/sdkconfig.defaults
@@ -18,3 +18,6 @@ CONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK=n
 # provisioned. The EID counter starts from the value passed to hubble_init()
 # and advances with uptime.
 CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME=y
+
+# For logging with with level and timestamp prefix
+CONFIG_LOG_VERSION_2=y

--- a/samples/esp-idf/sat-dtm/main/main.c
+++ b/samples/esp-idf/sat-dtm/main/main.c
@@ -20,6 +20,8 @@
 #include "esp_timer.h"
 #include "nvs_flash.h"
 
+#include "nimble/nimble_port.h"
+
 #include <hubble/hubble.h>
 #include <hubble/sat.h>
 #include <hubble/sat/dtm.h>
@@ -438,6 +440,13 @@ void app_main(void)
 		ret = nvs_flash_init();
 	}
 	ESP_ERROR_CHECK(ret);
+
+	/* Init Bluetooth (NimBLE) */
+	ret = nimble_port_init();
+	if (ret != ESP_OK) {
+		ESP_LOGE(APP_TAG, "Failed to init NimBLE stack, error: %d", ret);
+		return;
+	}
 
 	/* Init the sems */
 	_tx_task_sem = xSemaphoreCreateBinary();

--- a/samples/esp-idf/sat-dtm/sdkconfig.defaults
+++ b/samples/esp-idf/sat-dtm/sdkconfig.defaults
@@ -16,3 +16,6 @@ CONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK=n
 # Use device uptime as the counter source because we
 # don't need time for DTM mode
 CONFIG_HUBBLE_COUNTER_SOURCE_DEVICE_UPTIME=y
+
+# For logging with with level and timestamp prefix
+CONFIG_LOG_VERSION_2=y

--- a/samples/esp-idf/sat-dtm/sdkconfig.defaults
+++ b/samples/esp-idf/sat-dtm/sdkconfig.defaults
@@ -1,10 +1,14 @@
 # Copyright (c) 2026 Hubble Network, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Bluetooth
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+CONFIG_BT_NIMBLE_50_FEATURE_SUPPORT=n
+
 # Sat dependencies
 CONFIG_HUBBLE_SAT_NETWORK=y
 CONFIG_HUBBLE_SAT_NETWORK_DTM_MODE=y
-CONFIG_ESP_PHY_ENABLE_CERT_TEST=y
 
 # Disable nonce check since we don't need it for DTM
 CONFIG_HUBBLE_NETWORK_SECURITY_ENFORCE_NONCE_CHECK=n

--- a/samples/esp-idf/sat-dual-stack/sdkconfig.defaults
+++ b/samples/esp-idf/sat-dual-stack/sdkconfig.defaults
@@ -9,3 +9,6 @@ CONFIG_BT_NIMBLE_50_FEATURE_SUPPORT=n
 # Hubble Network
 CONFIG_HUBBLE_BLE_NETWORK=y
 CONFIG_HUBBLE_SAT_NETWORK=y
+
+# For logging with with level and timestamp prefix
+CONFIG_LOG_VERSION_2=y


### PR DESCRIPTION
Removing `rftest` dependency per Espressif recommendation.
For Hubble sat transmission to work, `esp_phy_enable()` must be called, which can be achieved by calling rftest or bt init. However, having rftest init cal at the same time as bt can cause issue for other SoCs.