### PR TITLE
crypto: Support referencing the Hubble key by a PSA key id

### DIFF
--- a/include/hubble/port/crypto.h
+++ b/include/hubble/port/crypto.h
@@ -102,6 +102,32 @@ int hubble_crypto_cmac(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 		       uint8_t output[HUBBLE_AES_BLOCK_SIZE]);
 
 /**
+ * @brief Computes the Cipher-based Message Authentication Code (CMAC)
+ *        using a key identifier.
+ *
+ * Same as hubble_crypto_cmac(), but the key is referenced by an opaque
+ * key identifier instead of by its key material. The SDK never has
+ * access to the key material: the application provisions the key into a
+ * secure key storage and the CMAC is computed by the crypto provider on
+ * the key it holds internally, so the raw key never leaves that storage.
+ *
+ * @param key_id Buffer holding the identifier of the key used for the
+ *               CMAC calculation, in the format expected by the crypto
+ *               provider (for PSA Crypto, a psa_key_id_t). It does not
+ *               contain key material.
+ * @param data Pointer to the input data for which the CMAC is
+ *             calculated.
+ * @param len The length of the input data in bytes.
+ * @param output Pointer to the buffer where the CMAC (message
+ *               authentication code) will be stored. This buffer must
+ *               be large enough to hold the CMAC value
+ *               (typically the size of the AES block, 16 bytes).
+ * @return 0 on success, non-zero on error.
+ */
+int hubble_crypto_key_id_cmac(const void *key_id, const uint8_t *data,
+			      size_t len, uint8_t output[HUBBLE_AES_BLOCK_SIZE]);
+
+/**
  * @}
  */ /* hubble_crypto */
 

--- a/port/zephyr/Kconfig
+++ b/port/zephyr/Kconfig
@@ -194,6 +194,21 @@ config HUBBLE_NETWORK_CRYPTO_PSA
 	  When building with TF-M, cryptographic operations are
 	  delegated to the secure processing environment.
 
+config HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID
+	bool "Use PSA Crypto opaque key id"
+	depends on HUBBLE_NETWORK_CRYPTO_PSA
+	help
+	  Reference the Hubble key by its PSA opaque key
+	  identifier instead of by its key material.
+
+	  With this option the SDK never needs nor has access to
+	  the Hubble key material. The application provisions the
+	  key into a secure key storage (for example TF-M ITS or
+	  a KMU) and hands the SDK only the key id returned by
+	  that storage. All cryptographic operations are then
+	  performed by the PSA implementation on the key it holds
+	  internally, so the Hubble key material is never directly used.
+
 config HUBBLE_NETWORK_CRYPTO_CUSTOM
 	bool "Custom crypto implementation"
 	help

--- a/samples/zephyr/ble-beacon/README.md
+++ b/samples/zephyr/ble-beacon/README.md
@@ -6,6 +6,9 @@ create a BLE beacon that advertises its presence.
 ## Requirements
 
 - Cryptographic key provided by Hubble Network
+- To keep the key out of the firmware, see
+  [Using a key stored in the KMU](#using-a-key-stored-in-the-kmu). That mode
+  requires an nRF54L15 device and the nRF Connect SDK.
 
 ## Overview
 
@@ -57,6 +60,64 @@ python ../../../tools/embed_key_time.py -b master.key -o ./src
 ```
 
 After running the script, the key and timestamp will be compiled into the application.
+
+## Using a key stored in the KMU
+
+Instead of embedding the key material in the firmware, the SDK can reference
+the key by its PSA key identifier. When
+`CONFIG_HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID` is enabled, the SDK never needs
+nor has access to the key material: the key is provisioned into the Key
+Management Unit (KMU) and every cryptographic operation is performed by CRACEN
+on the key it holds internally, so the key never leaves the secure storage.
+
+### Requirements
+
+- An nRF54L15 device, for example `nrf54l15dk/nrf54l15/cpuapp`. The KMU and the
+  CRACEN cryptographic accelerator are only available on this family.
+- The nRF Connect SDK, which provides the CRACEN PSA driver.
+- `nrfutil` with the `device` command, used to provision the key.
+
+### 1. Generate the key attributes
+
+The `ncs-generate-key.py` script describes the key for `nrfutil`: it takes the
+base64-encoded key and writes a JSON file with the key material and its PSA
+attributes (AES-CMAC, sign usage, PROTECTED usage scheme).
+
+```sh
+# Script is located in SDK_BASE/tools
+
+python ../../../tools/ncs-generate-key.py --id 1 --key "$(cat master.key)" --file keyslot.json
+```
+
+The sample expects the key in **KMU slot 1**. `src/key_id.c` builds the key
+identifier with `PSA_KEY_ID_FROM_CRACEN_KMU_SLOT(
+CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED, PSA_KEY_ID_USER_MIN)`, and
+`PSA_KEY_ID_USER_MIN` is slot 1.
+
+> [!NOTE]
+> A KMU slot holds 128 bits of key material, so a 256-bit key is stored across
+> slots 1 and 2. Pass `--key-bits 128` for a 128-bit key, and make sure the
+> size matches the one selected with `CONFIG_HUBBLE_NETWORK_KEY_256` or
+> `CONFIG_HUBBLE_NETWORK_KEY_128`.
+
+Run `python ../../../tools/ncs-generate-key.py --help` for the remaining
+options, such as `--persistence` to control whether the slot can be reused,
+revoked, or written only once.
+
+### 2. Provision the key
+
+```sh
+nrfutil device x-provision-keys --key-file keyslot.json
+```
+
+### 3. Build the sample
+
+The `ncs_cracen.conf` fragment selects the CRACEN driver and enables the key id
+support in the SDK:
+
+```sh
+west build -b nrf54l15dk/nrf54l15/cpuapp . -- -DEXTRA_CONF_FILE=ncs_cracen.conf
+```
 
 ## Building and Running
 

--- a/samples/zephyr/ble-beacon/ncs_cracen.conf
+++ b/samples/zephyr/ble-beacon/ncs_cracen.conf
@@ -1,0 +1,6 @@
+# Enable hardware crypto accelerator
+CONFIG_PSA_CRYPTO_DRIVER_OBERON=n
+CONFIG_PSA_CRYPTO_DRIVER_CRACEN=y
+
+# Set Hubble SDK to use key id
+CONFIG_HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID=y

--- a/samples/zephyr/ble-beacon/src/key_id.c
+++ b/samples/zephyr/ble-beacon/src/key_id.c
@@ -1,0 +1,10 @@
+#include <psa/crypto.h>
+
+#ifdef CONFIG_PSA_CRYPTO_DRIVER_CRACEN
+#include <cracen_psa_kmu.h>
+
+static const void *master_key = &(psa_key_id_t){PSA_KEY_ID_FROM_CRACEN_KMU_SLOT(
+	CRACEN_KMU_KEY_USAGE_SCHEME_PROTECTED, PSA_KEY_ID_USER_MIN)};
+#else
+#error "Not supported key storage backend."
+#endif

--- a/samples/zephyr/ble-beacon/src/main.c
+++ b/samples/zephyr/ble-beacon/src/main.c
@@ -17,7 +17,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef CONFIG_HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID
+#include "key_id.c"
+#else
 #include "key.c"
+#endif /* CONFIG_HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID */
+
 #include "time.c"
 
 LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);

--- a/src/crypto/psa.c
+++ b/src/crypto/psa.c
@@ -43,6 +43,15 @@ static int _psa_status_to_errno(psa_status_t status)
 	case PSA_ERROR_DATA_CORRUPT:
 		ret = -EBADMSG;
 		break;
+	case PSA_ERROR_INVALID_HANDLE:
+		ret = -EINVAL;
+		break;
+	case PSA_ERROR_NOT_SUPPORTED:
+		ret = -ENOTSUP;
+		break;
+	case PSA_ERROR_NOT_PERMITTED:
+		ret = -EPERM;
+		break;
 	default:
 		break;
 	}

--- a/src/crypto/psa.c
+++ b/src/crypto/psa.c
@@ -59,6 +59,35 @@ static int _psa_status_to_errno(psa_status_t status)
 	return ret;
 }
 
+int hubble_crypto_key_id_cmac(const void *key_id, const uint8_t *data,
+			      size_t len, uint8_t output[HUBBLE_AES_BLOCK_SIZE])
+{
+	psa_status_t status;
+	size_t mac_length = 0;
+	psa_mac_operation_t operation = PSA_MAC_OPERATION_INIT;
+
+	status = psa_mac_sign_setup(&operation, *(psa_key_id_t *)key_id,
+				    PSA_ALG_CMAC);
+	if (status != PSA_SUCCESS) {
+		goto mac_setup_error;
+	}
+
+	status = psa_mac_update(&operation, data, len);
+	if (status != PSA_SUCCESS) {
+		goto mac_update_error;
+	}
+
+	status = psa_mac_sign_finish(&operation, output, HUBBLE_AES_BLOCK_SIZE,
+				     &mac_length);
+mac_update_error:
+	/* A failed update or sign_finish leaves the operation in an error
+	 * state that must be aborted; aborting a completed one is a no-op.
+	 */
+	(void)psa_mac_abort(&operation);
+mac_setup_error:
+	return _psa_status_to_errno(status);
+}
+
 int hubble_crypto_cmac(const uint8_t key[CONFIG_HUBBLE_KEY_SIZE],
 		       const uint8_t *input, size_t input_len,
 		       uint8_t output[HUBBLE_AES_BLOCK_SIZE])

--- a/src/hubble_crypto.c
+++ b/src/hubble_crypto.c
@@ -142,8 +142,8 @@ int hubble_internal_sequence_acquire(uint32_t time_counter, uint16_t *seq_no)
 	return ret;
 }
 
-static int _kbkdf_counter(const uint8_t *key, const char *label,
-			  size_t label_len, const uint8_t *context,
+static int _kbkdf_counter(const uint8_t *key, const char *label, size_t label_len,
+			  bool hubble_key, const uint8_t *context,
 			  size_t context_len, uint8_t *output, size_t olen)
 {
 	int ret = 0;
@@ -188,9 +188,21 @@ static int _kbkdf_counter(const uint8_t *key, const char *label,
 		       (uint8_t *)&(uint32_t){HUBBLE_CPU_TO_BE32(counter)},
 		       sizeof(counter));
 
+#ifdef CONFIG_HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID
 		/* Perform AES-CMAC with the key and the prepared message */
+		if (hubble_key) {
+			ret = hubble_crypto_key_id_cmac(
+				key, message, message_length, prf_output);
+		} else {
+			ret = hubble_crypto_cmac(key, message, message_length,
+						 prf_output);
+		}
+#else
+		(void)hubble_key;
 		ret = hubble_crypto_cmac(key, message, message_length,
 					 prf_output);
+#endif
+
 		if (ret != 0) {
 			goto exit;
 		}
@@ -222,18 +234,19 @@ static int _derived_key_get(enum hubble_key_label label, uint32_t counter,
 	snprintf((char *)context, _CONTEXT_SIZE, "%" PRIu32, counter);
 	switch (label) {
 	case HUBBLE_DEVICE_KEY:
-		err = _kbkdf_counter(master_key, "DeviceKey", strlen("DeviceKey"),
-				     context, strlen((const char *)context),
-				     output_key, CONFIG_HUBBLE_KEY_SIZE);
+		err = _kbkdf_counter(master_key, "DeviceKey",
+				     strlen("DeviceKey"), true, context,
+				     strlen((const char *)context), output_key,
+				     CONFIG_HUBBLE_KEY_SIZE);
 		break;
 	case HUBBLE_NONCE_KEY:
 		err = _kbkdf_counter(master_key, "NonceKey", strlen("NonceKey"),
-				     context, strlen((const char *)context),
+				     true, context, strlen((const char *)context),
 				     output_key, CONFIG_HUBBLE_KEY_SIZE);
 		break;
 	case HUBBLE_ENCRYPTION_KEY:
 		err = _kbkdf_counter(master_key, "EncryptionKey",
-				     strlen("EncryptionKey"), context,
+				     strlen("EncryptionKey"), true, context,
 				     strlen((const char *)context), output_key,
 				     CONFIG_HUBBLE_KEY_SIZE);
 		break;
@@ -262,8 +275,9 @@ static int _derived_value_get(enum hubble_value_label label,
 		if (ret != 0) {
 			goto exit;
 		}
-		ret = _kbkdf_counter(derived_key, "DeviceID", strlen("DeviceID"),
-				     context, strlen((const char *)context),
+		ret = _kbkdf_counter(derived_key, "DeviceID",
+				     strlen("DeviceID"), false, context,
+				     strlen((const char *)context),
 				     output_value, output_len);
 		break;
 	case HUBBLE_NONCE_VALUE:
@@ -272,9 +286,9 @@ static int _derived_value_get(enum hubble_value_label label,
 		if (ret != 0) {
 			goto exit;
 		}
-		ret = _kbkdf_counter(derived_key, "Nonce", strlen("Nonce"),
-				     context, strlen((const char *)context),
-				     output_value, output_len);
+		ret = _kbkdf_counter(
+			derived_key, "Nonce", strlen("Nonce"), false, context,
+			strlen((const char *)context), output_value, output_len);
 		break;
 	case HUBBLE_ENCRYPTION_VALUE:
 		ret = _derived_key_get(HUBBLE_ENCRYPTION_KEY, time_counter,
@@ -282,8 +296,8 @@ static int _derived_value_get(enum hubble_value_label label,
 		if (ret != 0) {
 			goto exit;
 		}
-		ret = _kbkdf_counter(derived_key, "Key", strlen("Key"), context,
-				     strlen((const char *)context),
+		ret = _kbkdf_counter(derived_key, "Key", strlen("Key"), false,
+				     context, strlen((const char *)context),
 				     output_value, output_len);
 		break;
 	default:

--- a/tools/ncs-generate-key.py
+++ b/tools/ncs-generate-key.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Hubble Network, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Generate the PSA attributes of a Hubble key held in the CRACEN KMU.
+
+The key is an AES-128 or AES-256 key used to sign with CMAC. It lives in a
+KMU slot under the PROTECTED usage scheme, meaning CRACEN is the only one
+that ever sees the key material.
+
+The generated JSON is written to a file with --file, or to the console, and
+is provisioned to the device with:
+
+    nrfutil device x-provision-keys --key-file <file>
+"""
+
+import base64
+import binascii
+import json
+import struct
+from pathlib import Path
+
+import click
+
+# PSA values, see psa/crypto_values.h and nrf_security
+KEY_TYPE_AES = 0x2400
+ALG_CMAC = 0x03C00200
+USAGE_SIGN = 0x1400  # PSA_KEY_USAGE_SIGN_MESSAGE | PSA_KEY_USAGE_SIGN_HASH
+LOCATION_CRACEN_KMU = 0x804E4B00
+KMU_KEY_ID = 0x7FFF0000
+KMU_SCHEME_PROTECTED = 0 << 12
+
+# What happens to the slot once the key is destroyed
+PERSISTENCE = {
+    "DEFAULT": 1,  # the slot can be reused
+    "REVOKABLE": 2,  # the slot is revoked
+    "READ_ONLY": 3,  # the key can not be destroyed
+}
+
+
+def attributes(slot: int, key_bits: int, persistence: int) -> bytes:
+    """Pack the key attributes as the psa_key_attributes_s C struct."""
+    return struct.pack(
+        "<hhIIIIII",
+        KEY_TYPE_AES,
+        key_bits,
+        LOCATION_CRACEN_KMU | persistence,  # lifetime
+        USAGE_SIGN,
+        ALG_CMAC,
+        0,  # no second algorithm
+        KMU_KEY_ID | KMU_SCHEME_PROTECTED | slot,
+        0,  # reserved, only used if the key id encodes an owner
+    )
+
+
+def key_material(key: str, key_bits: int) -> bytes:
+    """Decode a base64 key and check that it has the expected size."""
+    try:
+        material = base64.b64decode(key.strip(), validate=True)
+    except binascii.Error as error:
+        raise click.BadParameter(f"not valid base64, {error}", param_hint="'--key'") from error
+
+    if len(material) != key_bits // 8:
+        raise click.BadParameter(
+            f"a {key_bits} bits key must decode to {key_bits // 8} bytes, got {len(material)}",
+            param_hint="'--key'",
+        )
+
+    return material
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--id", "slot", type=click.IntRange(0, 255), required=True, help="KMU slot number")
+@click.option("--key", required=True, help="Key material, base64 encoded")
+@click.option(
+    "--key-bits",
+    type=click.Choice([128, 256]),
+    default=256,
+    show_default=True,
+    help="AES key size in bits",
+)
+@click.option(
+    "--persistence",
+    type=click.Choice(PERSISTENCE),
+    default="DEFAULT",
+    show_default=True,
+    help="Fate of the slot when the key is destroyed",
+)
+@click.option(
+    "--file",
+    "path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="JSON file to write, created if missing and appended to otherwise",
+)
+def main(slot: int, key: str, key_bits: int, persistence: str, path: Path | None) -> None:
+    """Generate the PSA attributes of a Hubble key to be stored in a CRACEN KMU slot.
+
+    The output is a keyslot description that nrfutil provisions to the device with
+    `nrfutil device x-provision-keys --key-file <file>`.
+    """
+    keyslot = {
+        "metadata": "0x" + attributes(slot, key_bits, PERSISTENCE[persistence]).hex().upper(),
+        "value": "0x" + key_material(key, key_bits).hex(),
+    }
+
+    if path and path.is_file():
+        document = json.loads(path.read_text())
+    else:
+        document = {"version": 0, "keyslots": []}
+
+    document["keyslots"].append(keyslot)
+
+    output = json.dumps(document, indent=4)
+    if path:
+        path.write_text(output)
+    else:
+        click.echo(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add CONFIG_HUBBLE_NETWORK_CRYPTO_PSA_USE_KEY_ID, so the SDK signs through a key
the PSA implementation already holds and never sees the key material.

Includes tools/ncs-generate-key.py to build the nrfutil keyslot JSON, and a ble-beacon
sample setup provisioning the key into CRACEN KMU on nRF54L15